### PR TITLE
FIX: doInternalFilter를 통해서 요청 origin을 추적한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI Pipeline with Docker Hub
 on:
   push:
     branches: [develop, main]
-  pull_request:
-    branches: [develop, main]
 
 env:
   AWS_REGION: ap-northeast-2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI Pipeline with Docker Hub
 on:
   push:
     branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
 
 env:
   AWS_REGION: ap-northeast-2

--- a/src/main/java/hanieum/conik/global/adapter/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanieum/conik/global/adapter/security/jwt/JwtAuthenticationFilter.java
@@ -54,7 +54,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
 
         String token = resolveToken(httpServletRequest);
-        log.info("BearerToken: {}", token);
+        String uri = httpServletRequest.getRequestURI();
+        String ip = httpServletRequest.getRemoteAddr();
+        String forwarded = httpServletRequest.getHeader("X-Forwarded-For");
+
+        log.info("BearerToken: null, URI: {}, IP: {}, X-Forwarded-For: {}", uri, ip, forwarded);
 
         try {
             if (token != null) {

--- a/src/main/java/hanieum/conik/global/adapter/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanieum/conik/global/adapter/security/jwt/JwtAuthenticationFilter.java
@@ -21,11 +21,10 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-@Component
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-
     private final JwtTokenProviderPort jwtTokenProviderPort;
 
     // JWT 검증을 제외할 경로
@@ -41,7 +40,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/v1/auth/signup",
             "/v1/auth/login",
             "/v1/email",
-            "/v1/email/certificate"
+            "/v1/email/certificate",
+            // Health check endpoint
+            "/actuator/health/readiness",
+            "/actuator/health/liveness"
     );
 
     @Override
@@ -51,14 +53,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
-
+    protected void doFilterInternal(HttpServletRequest httpServletRequest,
+                                    HttpServletResponse httpServletResponse,
+                                    FilterChain filterChain) throws ServletException, IOException {
         String token = resolveToken(httpServletRequest);
-        String uri = httpServletRequest.getRequestURI();
-        String ip = httpServletRequest.getRemoteAddr();
-        String forwarded = httpServletRequest.getHeader("X-Forwarded-For");
-
-        log.info("BearerToken: null, URI: {}, IP: {}, X-Forwarded-For: {}", uri, ip, forwarded);
 
         try {
             if (token != null) {

--- a/src/main/java/hanieum/conik/global/config/SecurityConfig.java
+++ b/src/main/java/hanieum/conik/global/config/SecurityConfig.java
@@ -19,7 +19,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -32,7 +31,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize ->
                         authorize
                                 .requestMatchers(HttpMethod.OPTIONS, "/v1/**").permitAll()
-                                .requestMatchers("/actuator/health/**").permitAll()
+                                .requestMatchers(
+                                        "/actuator/health/readiness",
+                                        "/actuator/health/liveness"
+                                ).permitAll()
                                 .requestMatchers(
                                         "/v1/auth/signup",
                                         "/v1/auth/login",


### PR DESCRIPTION
## 💡 관련 이슈
- #38 

## 📝 작업 내용
> 현재 불필요한 헬스체크 로그들이 10여초마다 찍히고 있습니다.
<img width="1002" height="351" alt="image (1)" src="https://github.com/user-attachments/assets/0c900570-5d0c-4875-84e0-7bfb3866d93d" />

- [x] .permitAll 에 헬스체크 포인트를 추가한다.
- [x] ShouldNotFilter에 헬스체크 포인트를 추가한다.


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요
구체적으로 필요한 엔드포인트를 지정해서 필터체인과, ShouldNotFilter에 등록하였습니다.

## 💬 리뷰 요구사항(선택)
[아카이브](https://www.notion.so/archive-2282f23b094f80139cf1f18d18248aa3?source=copy_link) 해당 노션 아카이브 탭에 간단하게 정리해두었습니다.
