### PR TITLE
FIX: 사용자 로그인 응답 구조 변경 및 프로젝트 응답구조에 도면파일 추가하기

### DIFF
--- a/src/main/java/hanieum/conik/adapter/project/dto/response/MemberProjectQueryResponse.java
+++ b/src/main/java/hanieum/conik/adapter/project/dto/response/MemberProjectQueryResponse.java
@@ -4,11 +4,15 @@ import hanieum.conik.adapter.project.dto.request.ProjectRegisterRequest;
 import hanieum.conik.domain.project.entity.ProjectDrawingFile;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record MemberProjectQueryResponse(
         @Schema(description = "프로젝트 PK", example = "1")
         Long projectId,
+
+        @Schema(description = "프로젝트 최종 수정일시", example = "2024-01-15T10:30:00")
+        LocalDateTime modifiedAt,
 
         @Schema(description = "프로젝트 상세 내용")
         ProjectRegisterRequest projectRegisterRequest,
@@ -16,10 +20,10 @@ public record MemberProjectQueryResponse(
         @Schema(description = "프로젝트 도면 파일 목록")
         List<String> drawingUrls
 ) {
-    public static MemberProjectQueryResponse from(Long projectId, ProjectRegisterRequest projectRegisterRequest, List<ProjectDrawingFile> drawingFiles) {
+    public static MemberProjectQueryResponse from(Long projectId, LocalDateTime modifiedAt, ProjectRegisterRequest projectRegisterRequest, List<ProjectDrawingFile> drawingFiles) {
         List<String> drawingUrls = drawingFiles.stream()
                 .map(ProjectDrawingFile::getDrawingUrl)
                 .toList();
-        return new MemberProjectQueryResponse(projectId, projectRegisterRequest, drawingUrls);
+        return new MemberProjectQueryResponse(projectId, modifiedAt, projectRegisterRequest, drawingUrls);
     }
 }

--- a/src/main/java/hanieum/conik/adapter/project/dto/response/MemberProjectQueryResponse.java
+++ b/src/main/java/hanieum/conik/adapter/project/dto/response/MemberProjectQueryResponse.java
@@ -1,16 +1,25 @@
 package hanieum.conik.adapter.project.dto.response;
 
 import hanieum.conik.adapter.project.dto.request.ProjectRegisterRequest;
+import hanieum.conik.domain.project.entity.ProjectDrawingFile;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
 
 public record MemberProjectQueryResponse(
         @Schema(description = "프로젝트 PK", example = "1")
         Long projectId,
 
         @Schema(description = "프로젝트 상세 내용")
-        ProjectRegisterRequest projectRegisterRequest
+        ProjectRegisterRequest projectRegisterRequest,
+
+        @Schema(description = "프로젝트 도면 파일 목록")
+        List<String> drawingUrls
 ) {
-    public static MemberProjectQueryResponse from(Long projectId, ProjectRegisterRequest projectRegisterRequest) {
-        return new MemberProjectQueryResponse(projectId, projectRegisterRequest);
+    public static MemberProjectQueryResponse from(Long projectId, ProjectRegisterRequest projectRegisterRequest, List<ProjectDrawingFile> drawingFiles) {
+        List<String> drawingUrls = drawingFiles.stream()
+                .map(ProjectDrawingFile::getDrawingUrl)
+                .toList();
+        return new MemberProjectQueryResponse(projectId, projectRegisterRequest, drawingUrls);
     }
 }

--- a/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
+++ b/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
@@ -15,9 +15,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @Tag(name = "PROJECT")
@@ -63,9 +65,10 @@ public class ProjectController {
     @Operation(summary = "사용자 프로젝트(공고) 조회 API", description = "사용자의 프로젝트(공고) 목록을 조회합니다.")
     @GetMapping("/{memberId}")
     @AuthorizeUser(sourceType = AuthSourceType.PATH_VARIABLE, paramName = "memberId")
-    public ApiResponse<List<MemberProjectQueryResponse>> getMemberProjects(@RequestParam(value = "status", required = false) SubmitStatus submitStatus,
-                                                                           @PathVariable("memberId") Long memberId) {
-        return ApiResponse.success(projectFinder.getMemberProjects(memberId, submitStatus));
+    public ApiResponse<Page<MemberProjectQueryResponse>> getMemberProjects(@RequestParam(value = "status", required = false) SubmitStatus submitStatus,
+                                                                           @PathVariable("memberId") Long memberId,
+                                                                           @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.success(projectFinder.getMemberProjects(memberId, submitStatus, pageable));
     }
 
     @Operation(summary = "프로젝트(공고) 입찰 상태 변경 API", description = "프로젝트(공고)의 입찰 상태를 변경합니다.")

--- a/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalResponse.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalResponse.java
@@ -3,15 +3,20 @@ package hanieum.conik.adapter.proposal.dto.response;
 import hanieum.conik.adapter.proposal.dto.request.ProposalRegisterRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
+
 public record ProposalResponse(
     @Schema(description = "기업 견적서 PK", example = "1")
     Long proposalId,
 
+    @Schema(description = "기업 견적서 최종 수정일시", example = "2024-01-15T10:30:00")
+    LocalDateTime modifiedAt,
+
     @Schema(description = "기업 견적서 상세 내용")
     ProposalRegisterRequest proposalRegisterRequest
 ) {
-    public static ProposalResponse from(Long proposalId, ProposalRegisterRequest proposalRegisterRequest) {
-        return new ProposalResponse(proposalId, proposalRegisterRequest);
+    public static ProposalResponse from(Long proposalId, LocalDateTime modifiedAt, ProposalRegisterRequest proposalRegisterRequest) {
+        return new ProposalResponse(proposalId, modifiedAt, proposalRegisterRequest);
     }
 }
 

--- a/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
@@ -8,7 +8,6 @@ import hanieum.conik.application.proposal.provided.ProposalDrawingSaver;
 import hanieum.conik.application.proposal.provided.ProposalFinder;
 import hanieum.conik.application.proposal.provided.ProposalSaver;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
-import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import hanieum.conik.domain.proposal.domain.enumerate.ProposalBidStatus;
 import hanieum.conik.global.adapter.security.AuthSourceType;
 import hanieum.conik.global.adapter.security.AuthorizeUser;
@@ -17,9 +16,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @Tag(name = "PROPOSAL")
@@ -63,10 +64,11 @@ public class ProposalController {
     @Operation(summary = "프로젝트별 기업 견적서(입찰) 조회 API", description = "기업 견적서(입찰) 목록을 조회합니다.")
     @GetMapping("/{memberId}")
     @AuthorizeUser(sourceType = AuthSourceType.PATH_VARIABLE, paramName = "memberId")
-    public ApiResponse<List<ProposalDetailResponse>> getCompanyProposals(@PathVariable("memberId") Long memberId,
+    public ApiResponse<Page<ProposalDetailResponse>> getCompanyProposals(@PathVariable("memberId") Long memberId,
                                                                          @RequestParam(required = false) SubmitStatus status,
-                                                                         @RequestParam(required = false) Long projectId) {
-        return ApiResponse.success(proposalFinder.getCompanyProposals(memberId, projectId, status));
+                                                                         @RequestParam(required = false) Long projectId,
+                                                                         @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.success(proposalFinder.getCompanyProposals(memberId, projectId, status, pageable)) ;
     }
 
     @Operation(summary = "기업 견적서(입찰) 요청 API", description = "입찰에 참여한 기업 중에 골라서 거래를 요청합니다.")

--- a/src/main/java/hanieum/conik/application/member/AuthService.java
+++ b/src/main/java/hanieum/conik/application/member/AuthService.java
@@ -1,15 +1,13 @@
 package hanieum.conik.application.member;
 
 import hanieum.conik.application.company.required.CompanyRepository;
-import hanieum.conik.domain.member.dto.MemberLoginResponse;
+import hanieum.conik.domain.member.dto.*;
 import hanieum.conik.application.member.provided.Auth;
 import hanieum.conik.application.member.required.MemberRepository;
 import hanieum.conik.domain.company.Company;
 import hanieum.conik.domain.company.exception.CompanyErrorType;
 import hanieum.conik.domain.company.exception.CompanyException;
 import hanieum.conik.domain.member.Member;
-import hanieum.conik.domain.member.dto.MemberLoginRequest;
-import hanieum.conik.domain.member.dto.MemberSignUpRequest;
 import hanieum.conik.domain.member.exception.MemberErrorType;
 import hanieum.conik.domain.member.exception.MemberException;
 import hanieum.conik.domain.member.shared.Email;
@@ -22,7 +20,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
-
 
 @Service
 @Transactional
@@ -38,13 +35,14 @@ public class AuthService implements Auth {
 
     @Override
     public MemberLoginResponse signUpIndividual(MemberSignUpRequest request) {
+        System.out.println(1);
         checkDuplicateEmail(request);
-
+        System.out.println(2);
         Member member = Member.signUpIndividual(getHashedRequest(request));
-
+        System.out.println(3);
         memberRepository.save(member);
 
-        return login(new MemberLoginRequest(member.getEmail().address(), request.password()));
+        return login(MemberLoginRequest.from(request));
     }
 
     @Override
@@ -57,7 +55,7 @@ public class AuthService implements Auth {
 
         memberRepository.save(member);
 
-        return login(new MemberLoginRequest(member.getEmail().address(), request.password()));
+        return login(MemberLoginRequest.from(request));
     }
 
     @Override
@@ -72,7 +70,7 @@ public class AuthService implements Auth {
             String key = "auth:refresh:" + member.getId();
             memoryMap.setValue(key, refreshToken, jwtTokenProviderPort.getRefreshTokenExpiration());
 
-            return new MemberLoginResponse(accessToken, refreshToken, member.getId());
+            return new MemberLoginResponse(TokenInfo.of(accessToken, refreshToken), MemberInfo.from(member));
         } else {
             throw new MemberException(MemberErrorType.INVALID_PASSWORD);
         }
@@ -87,6 +85,6 @@ public class AuthService implements Auth {
     private MemberSignUpRequest getHashedRequest(MemberSignUpRequest request) {
         String hashedPassword = passwordEncoder.encode(request.password());
 
-        return new MemberSignUpRequest(request.email(), hashedPassword, request.phoneNumber(), request.termsOfServiceAgreed());
+        return request.withHashedPassword(hashedPassword);
     }
 }

--- a/src/main/java/hanieum/conik/application/member/AuthService.java
+++ b/src/main/java/hanieum/conik/application/member/AuthService.java
@@ -1,6 +1,7 @@
 package hanieum.conik.application.member;
 
 import hanieum.conik.application.company.required.CompanyRepository;
+import hanieum.conik.application.member.provided.TokenRefresh;
 import hanieum.conik.domain.member.dto.*;
 import hanieum.conik.application.member.provided.Auth;
 import hanieum.conik.application.member.required.MemberRepository;

--- a/src/main/java/hanieum/conik/application/member/AuthService.java
+++ b/src/main/java/hanieum/conik/application/member/AuthService.java
@@ -35,11 +35,8 @@ public class AuthService implements Auth, TokenRefresh {
 
     @Override
     public MemberLoginResponse signUpIndividual(MemberSignUpRequest request) {
-        System.out.println(1);
         checkDuplicateEmail(request);
-        System.out.println(2);
         Member member = Member.signUpIndividual(getHashedRequest(request));
-        System.out.println(3);
         memberRepository.save(member);
 
         return login(MemberLoginRequest.from(request));

--- a/src/main/java/hanieum/conik/application/project/ProjectDrawingModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectDrawingModifyService.java
@@ -3,7 +3,9 @@ package hanieum.conik.application.project;
 import hanieum.conik.adapter.project.dto.request.ProjectDrawingUploadRequest;
 import hanieum.conik.application.project.provided.ProjectDrawingFinder;
 import hanieum.conik.application.project.provided.ProjectDrawingSaver;
+import hanieum.conik.application.project.provided.ProjectFinder;
 import hanieum.conik.application.project.required.ProjectDrawingRepository;
+import hanieum.conik.domain.project.entity.Project;
 import hanieum.conik.domain.project.entity.ProjectDrawingFile;
 import hanieum.conik.domain.project.exception.ProjectErrorType;
 import hanieum.conik.domain.project.exception.ProjectException;
@@ -19,12 +21,16 @@ import java.util.List;
 public class ProjectDrawingModifyService implements ProjectDrawingSaver {
      private final ProjectDrawingRepository projectDrawingRepository;
      private final ProjectDrawingFinder projectDrawingFinder;
+     private final ProjectFinder projectFinder;
 
      @Override
      public void saveDrawingFileTemp(ProjectDrawingUploadRequest projectDrawingUploadRequest) {
          try {
-             ProjectDrawingFile projectDrawingFile = ProjectDrawingFile.create(projectDrawingUploadRequest);
-             projectDrawingRepository.save(projectDrawingFile);
+             Project project = projectFinder.findProject(projectDrawingUploadRequest.projectId());
+             ProjectDrawingFile drawingFile = ProjectDrawingFile.create(projectDrawingUploadRequest);
+
+             project.addDrawing(drawingFile);
+             projectDrawingRepository.save(drawingFile);
          }
          catch (Exception e) {
              throw new ProjectException(ProjectErrorType.PROJECT_DRAWING_SAVE_ERROR);

--- a/src/main/java/hanieum/conik/application/project/ProjectDrawingModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectDrawingModifyService.java
@@ -27,7 +27,7 @@ public class ProjectDrawingModifyService implements ProjectDrawingSaver {
      public void saveDrawingFileTemp(ProjectDrawingUploadRequest projectDrawingUploadRequest) {
          try {
              Project project = projectFinder.findProject(projectDrawingUploadRequest.projectId());
-             ProjectDrawingFile drawingFile = ProjectDrawingFile.create(projectDrawingUploadRequest);
+             ProjectDrawingFile drawingFile = ProjectDrawingFile.create(project, projectDrawingUploadRequest);
 
              project.addDrawing(drawingFile);
              projectDrawingRepository.save(drawingFile);

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -29,7 +29,7 @@ public class ProjectModifyService implements ProjectSaver {
         try {
             Project project = Project.initiate(memberId);
             projectRepository.save(project);
-            return MemberProjectQueryResponse.from(project.getId(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
+            return MemberProjectQueryResponse.from(project.getId(), project.getModifiedAt(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
         } catch (Exception e) {
             throw new ProjectException(ProjectErrorType.PROJECT_INITIATE_ERROR);
         }
@@ -57,7 +57,7 @@ public class ProjectModifyService implements ProjectSaver {
             Project project = projectFinder.findProject(projectId);
             project.updateBidStatusAndPublicUntil(bidStatusUpdateRequest);
             projectRepository.save(project);
-            return MemberProjectQueryResponse.from(project.getId(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
+            return MemberProjectQueryResponse.from(project.getId(), project.getModifiedAt(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
         } catch (Exception e) {
             log.error("에러 발생", e);
             throw new ProjectException(ProjectErrorType.PROJECT_BID_STATUS_UPDATE_ERROR);
@@ -73,7 +73,7 @@ public class ProjectModifyService implements ProjectSaver {
 
             projectRepository.save(project);
 
-            return MemberProjectQueryResponse.from(projectId, ProjectRegisterRequest.from(project), project.getDrawingFiles());
+            return MemberProjectQueryResponse.from(projectId, project.getModifiedAt(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
         } catch (Exception e) {
             log.error("에러 발생", e);
             throw new ProjectException(ProjectErrorType.PROJECT_SAVE_ERROR);

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -7,6 +7,7 @@ import hanieum.conik.application.project.provided.ProjectFinder;
 import hanieum.conik.application.project.provided.ProjectSaver;
 import hanieum.conik.application.project.required.ProjectRepository;
 import hanieum.conik.domain.project.entity.Project;
+import hanieum.conik.domain.project.entity.ProjectDrawingFile;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.domain.project.exception.ProjectErrorType;
 import hanieum.conik.domain.project.exception.ProjectException;
@@ -67,6 +68,9 @@ public class ProjectModifyService implements ProjectSaver {
         try {
             Project project = projectFinder.findProject(projectId);
             project.update(request);
+
+            project.getDrawingFiles().forEach(ProjectDrawingFile::updateUploadStatus);
+
             projectRepository.save(project);
 
             return MemberProjectQueryResponse.from(projectId, ProjectRegisterRequest.from(project), project.getDrawingFiles());

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -11,9 +11,11 @@ import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.domain.project.exception.ProjectErrorType;
 import hanieum.conik.domain.project.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -56,6 +58,7 @@ public class ProjectModifyService implements ProjectSaver {
             projectRepository.save(project);
             return MemberProjectQueryResponse.from(project.getId(), ProjectRegisterRequest.from(project));
         } catch (Exception e) {
+            log.error("에러 발생", e);
             throw new ProjectException(ProjectErrorType.PROJECT_BID_STATUS_UPDATE_ERROR);
         }
     }
@@ -67,6 +70,7 @@ public class ProjectModifyService implements ProjectSaver {
             projectRepository.save(project);
             return MemberProjectQueryResponse.from(projectId, ProjectRegisterRequest.from(project));
         } catch (Exception e) {
+            log.error("에러 발생", e);
             throw new ProjectException(ProjectErrorType.PROJECT_SAVE_ERROR);
         }
     }

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -28,7 +28,7 @@ public class ProjectModifyService implements ProjectSaver {
         try {
             Project project = Project.initiate(memberId);
             projectRepository.save(project);
-            return MemberProjectQueryResponse.from(project.getId(), ProjectRegisterRequest.from(project));
+            return MemberProjectQueryResponse.from(project.getId(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
         } catch (Exception e) {
             throw new ProjectException(ProjectErrorType.PROJECT_INITIATE_ERROR);
         }
@@ -56,7 +56,7 @@ public class ProjectModifyService implements ProjectSaver {
             Project project = projectFinder.findProject(projectId);
             project.updateBidStatusAndPublicUntil(bidStatusUpdateRequest);
             projectRepository.save(project);
-            return MemberProjectQueryResponse.from(project.getId(), ProjectRegisterRequest.from(project));
+            return MemberProjectQueryResponse.from(project.getId(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
         } catch (Exception e) {
             log.error("에러 발생", e);
             throw new ProjectException(ProjectErrorType.PROJECT_BID_STATUS_UPDATE_ERROR);
@@ -68,7 +68,8 @@ public class ProjectModifyService implements ProjectSaver {
             Project project = projectFinder.findProject(projectId);
             project.update(request);
             projectRepository.save(project);
-            return MemberProjectQueryResponse.from(projectId, ProjectRegisterRequest.from(project));
+
+            return MemberProjectQueryResponse.from(projectId, ProjectRegisterRequest.from(project), project.getDrawingFiles());
         } catch (Exception e) {
             log.error("에러 발생", e);
             throw new ProjectException(ProjectErrorType.PROJECT_SAVE_ERROR);

--- a/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
@@ -30,13 +30,21 @@ public class ProjectQueryService implements ProjectFinder {
 
     @Override
     public List<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus) {
-        List<Project> projects = (submitStatus == null)
-                ? projectRepository.findByMemberId(memberId)
-                : projectRepository.findByMemberIdAndSubmitStatus(memberId, submitStatus);
+        List<Project> projects = findProjectsWithStatus(submitStatus, memberId);
 
         return projects.stream()
-                .map(project -> MemberProjectQueryResponse.from(project.getId(), ProjectRegisterRequest.from(project)))
+                .map(project -> MemberProjectQueryResponse.from(
+                        project.getId(),
+                        ProjectRegisterRequest.from(project),
+                        project.getDrawingFiles()
+                ))
                 .collect(Collectors.toList());
+    }
+
+    private List<Project> findProjectsWithStatus(SubmitStatus submitStatus, Long memberId) {
+        return (submitStatus == null)
+                ? projectRepository.findByMemberIdAndSubmitStatusIn(memberId, List.of(SubmitStatus.TEMPORARY_SAVE, SubmitStatus.SUBMIT))
+                : projectRepository.findByMemberIdAndSubmitStatus(memberId, submitStatus);
     }
 
     @Override

--- a/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
@@ -35,6 +35,7 @@ public class ProjectQueryService implements ProjectFinder {
 
         return projects.map(project -> MemberProjectQueryResponse.from(
                         project.getId(),
+                        project.getModifiedAt(),
                         ProjectRegisterRequest.from(project),
                         project.getDrawingFiles()
                 ));

--- a/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
@@ -9,12 +9,13 @@ import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.domain.project.exception.ProjectErrorType;
 import hanieum.conik.domain.project.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,22 +30,20 @@ public class ProjectQueryService implements ProjectFinder {
     }
 
     @Override
-    public List<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus) {
-        List<Project> projects = findProjectsWithStatus(submitStatus, memberId);
+    public Page<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable) {
+        Page<Project> projects = findProjectsWithStatus(submitStatus, memberId, pageable);
 
-        return projects.stream()
-                .map(project -> MemberProjectQueryResponse.from(
+        return projects.map(project -> MemberProjectQueryResponse.from(
                         project.getId(),
                         ProjectRegisterRequest.from(project),
                         project.getDrawingFiles()
-                ))
-                .collect(Collectors.toList());
+                ));
     }
 
-    private List<Project> findProjectsWithStatus(SubmitStatus submitStatus, Long memberId) {
+    private Page<Project> findProjectsWithStatus(SubmitStatus submitStatus, Long memberId, Pageable pageable) {
         return (submitStatus == null)
-                ? projectRepository.findByMemberIdAndSubmitStatusIn(memberId, List.of(SubmitStatus.TEMPORARY_SAVE, SubmitStatus.SUBMIT))
-                : projectRepository.findByMemberIdAndSubmitStatus(memberId, submitStatus);
+                ? projectRepository.findByMemberIdAndSubmitStatusIn(memberId, List.of(SubmitStatus.TEMPORARY_SAVE, SubmitStatus.SUBMIT), pageable)
+                : projectRepository.findByMemberIdAndSubmitStatus(memberId, submitStatus, pageable);
     }
 
     @Override

--- a/src/main/java/hanieum/conik/application/project/provided/ProjectFinder.java
+++ b/src/main/java/hanieum/conik/application/project/provided/ProjectFinder.java
@@ -3,13 +3,13 @@ package hanieum.conik.application.project.provided;
 import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
 import hanieum.conik.domain.project.entity.Project;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ProjectFinder {
     Project findProject(Long projectId);
 
     Project validateProjectOpenStatus(Long projectId);
 
-    List<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus);
+    Page<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable);
 }

--- a/src/main/java/hanieum/conik/application/project/required/ProjectRepository.java
+++ b/src/main/java/hanieum/conik/application/project/required/ProjectRepository.java
@@ -2,6 +2,8 @@ package hanieum.conik.application.project.required;
 
 import hanieum.conik.domain.project.entity.Project;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,8 +11,8 @@ import java.util.List;
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByMemberId(Long memberId);
 
-    List<Project> findByMemberIdAndSubmitStatus(Long memberId, SubmitStatus submitStatus);
+    Page<Project> findByMemberIdAndSubmitStatus(Long memberId, SubmitStatus submitStatus, Pageable pageable);
 
-    List<Project> findByMemberIdAndSubmitStatusIn(Long memberId, List<SubmitStatus> submitStatuses);
+    Page<Project> findByMemberIdAndSubmitStatusIn(Long memberId, List<SubmitStatus> submitStatuses, Pageable pageable);
 }
 

--- a/src/main/java/hanieum/conik/application/project/required/ProjectRepository.java
+++ b/src/main/java/hanieum/conik/application/project/required/ProjectRepository.java
@@ -10,5 +10,7 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByMemberId(Long memberId);
 
     List<Project> findByMemberIdAndSubmitStatus(Long memberId, SubmitStatus submitStatus);
+
+    List<Project> findByMemberIdAndSubmitStatusIn(Long memberId, List<SubmitStatus> submitStatuses);
 }
 

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -47,7 +47,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
             Proposal proposal = Proposal.initiate(memberFinder.find(memberId), project);
             proposalRepository.save(proposal);
 
-            return ProposalResponse.from(proposal.getId(), ProposalRegisterRequest.from(proposal));
+            return ProposalResponse.from(proposal.getId(),proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
         } catch (Exception e) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_INITIATE_ERROR);
         }
@@ -78,7 +78,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
             handler.accept(proposal);
 
             proposalRepository.save(proposal);
-            return ProposalResponse.from(proposal.getId(), ProposalRegisterRequest.from(proposal));
+            return ProposalResponse.from(proposal.getId(), proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
         } catch (Exception e) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_SAVE_ERROR);
         }
@@ -101,7 +101,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
         }
         Proposal proposal = proposalFinder.findProposal(proposalId);
         proposal.updateToBidRequested();
-        return ProposalResponse.from(proposal.getId(), ProposalRegisterRequest.from(proposal));
+        return ProposalResponse.from(proposal.getId(), proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
     }
 
     @Override
@@ -112,7 +112,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
         Proposal proposal = proposalFinder.findProposal(proposalId);
         proposal.acceptDeal();
         /** 거래 상태 레코드 생성 로직 추가**/
-        return ProposalResponse.from(proposal.getId(), ProposalRegisterRequest.from(proposal));
+        return ProposalResponse.from(proposal.getId(), proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
     }
 
     @Override
@@ -122,6 +122,6 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
         }
         Proposal proposal = proposalFinder.findProposal(proposalId);
         proposal.rejectDeal();
-        return ProposalResponse.from(proposal.getId(), ProposalRegisterRequest.from(proposal));
+        return ProposalResponse.from(proposal.getId(), proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
     }
 }

--- a/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
@@ -10,6 +10,8 @@ import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import hanieum.conik.domain.proposal.exception.ProposalErrorType;
 import hanieum.conik.domain.proposal.exception.ProposalException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,26 +31,24 @@ public class ProposalQueryService implements ProposalFinder {
     }
 
     @Override
-    public List<ProposalDetailResponse> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus) {
+    public Page<ProposalDetailResponse> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus, Pageable pageable) {
         Member member = memberFinder.find(memberId);
         Long companyId = member.getCompanyId();
 
-        List<Proposal> proposals = findProposalsWithStatus(submitStatus, companyId, projectId);
+        Page<Proposal> proposals = findProposalsWithStatus(submitStatus, companyId, projectId, pageable);
 
-        return proposals.stream()
-                .map(ProposalDetailResponse::from)
-                .toList();
+        return proposals.map(ProposalDetailResponse::from);
     }
 
-    private List<Proposal> findProposalsWithStatus(SubmitStatus submitStatus, Long companyId, Long projectId) {
+    private Page<Proposal> findProposalsWithStatus(SubmitStatus submitStatus, Long companyId, Long projectId, Pageable pageable) {
         if (projectId == null) {
             return (submitStatus == null)
-                    ? proposalRepository.findByCompanyIdAndSubmitStatusIn(companyId, List.of(SubmitStatus.TEMPORARY_SAVE, SubmitStatus.SUBMIT))
-                    : proposalRepository.findByCompanyIdAndSubmitStatus(companyId, submitStatus);
+                    ? proposalRepository.findByCompanyIdAndSubmitStatusIn(companyId, List.of(SubmitStatus.TEMPORARY_SAVE, SubmitStatus.SUBMIT), pageable)
+                    : proposalRepository.findByCompanyIdAndSubmitStatus(companyId, submitStatus, pageable);
         } else {
             return (submitStatus == null)
-                    ? proposalRepository.findByCompanyIdAndProjectIdAndSubmitStatusIn(companyId, projectId, List.of(SubmitStatus.TEMPORARY_SAVE, SubmitStatus.SUBMIT))
-                    : proposalRepository.findByCompanyIdAndProjectIdAndSubmitStatus(companyId, projectId, submitStatus);
+                    ? proposalRepository.findByCompanyIdAndProjectIdAndSubmitStatusIn(companyId, projectId, List.of(SubmitStatus.TEMPORARY_SAVE, SubmitStatus.SUBMIT), pageable)
+                    : proposalRepository.findByCompanyIdAndProjectIdAndSubmitStatus(companyId, projectId, submitStatus, pageable);
         }
     }
 

--- a/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
+++ b/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
@@ -3,11 +3,11 @@ package hanieum.conik.application.proposal.provided;
 import hanieum.conik.adapter.proposal.dto.response.ProposalDetailResponse;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.domain.proposal.domain.entity.Proposal;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ProposalFinder {
     Proposal findProposal(Long proposalId);
 
-    List<ProposalDetailResponse> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus);
+    Page<ProposalDetailResponse> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus, Pageable pageable);
 }

--- a/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
+++ b/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
@@ -2,14 +2,20 @@ package hanieum.conik.application.proposal.required;
 
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.domain.proposal.domain.entity.Proposal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
     List<Proposal> findByCompanyId(Long companyId);
-    List<Proposal> findByCompanyIdAndSubmitStatus(Long companyId, SubmitStatus submitStatus);
-    List<Proposal> findByCompanyIdAndSubmitStatusIn(Long companyId, List<SubmitStatus> submitStatuses);
-    List<Proposal> findByCompanyIdAndProjectIdAndSubmitStatusIn(Long companyId, Long projectId, List<SubmitStatus> submitStatuses);
-    List<Proposal> findByCompanyIdAndProjectIdAndSubmitStatus(Long companyId, Long projectId, SubmitStatus submitStatuses);
+
+    Page<Proposal> findByCompanyIdAndSubmitStatusIn(Long companyId, List<SubmitStatus> submitStatuses, Pageable pageable);
+
+    Page<Proposal> findByCompanyIdAndSubmitStatus(Long companyId, SubmitStatus submitStatus, Pageable pageable);
+
+    Page<Proposal> findByCompanyIdAndProjectIdAndSubmitStatusIn(Long companyId, Long projectId, List<SubmitStatus> submitStatuses, Pageable pageable);
+
+    Page<Proposal> findByCompanyIdAndProjectIdAndSubmitStatus(Long companyId, Long projectId, SubmitStatus submitStatus, Pageable pageable);
 }

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -24,6 +24,9 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 20)
+    private String name;
+
     @NaturalId
     @Convert(converter = EmailAttributeConverter.class)
     @Column(name = "email", nullable = false, unique = true, length = 100)
@@ -45,10 +48,11 @@ public class Member extends BaseEntity {
     @Column(name = "company_id", nullable = true)
     private Long companyId;
 
-    private Member(Email email, String hashedPassword, String phoneNumber, Boolean termsOfServiceAgreed, MemberRole role) {
+    private Member(String name, Email email, String hashedPassword, String phoneNumber, Boolean termsOfServiceAgreed, MemberRole role) {
         if (!termsOfServiceAgreed) {
             throw new MemberException(MemberErrorType.TERMS_NOT_AGREED);
         }
+        this.name = name;
         this.email = email;
         this.hashedPassword = hashedPassword;
         this.phoneNumber = phoneNumber;
@@ -60,14 +64,29 @@ public class Member extends BaseEntity {
      * 개인 회원가입
      * */
     public static Member signUpIndividual(MemberSignUpRequest request) {
-        return new Member(new Email(request.email()), request.password(), request.phoneNumber(), request.termsOfServiceAgreed(), MemberRole.INDIVIDUAL);
+        System.out.println(request.email());
+        return new Member(
+                request.name(),
+                new Email(request.email()),
+                request.password(),
+                request.phoneNumber(),
+                request.termsOfServiceAgreed(),
+                MemberRole.INDIVIDUAL
+        );
     }
 
     /**
      * 기업 회원가입
      * */
     public static Member signUpCompanyMember(MemberSignUpRequest request, Long companyId) {
-        Member member = new Member(new Email(request.email()), request.password(), request.phoneNumber(), request.termsOfServiceAgreed(), MemberRole.OWNER);
+        Member member = new Member(
+                request.name(),
+                new Email(request.email()),
+                request.password(),
+                request.phoneNumber(),
+                request.termsOfServiceAgreed(),
+                MemberRole.OWNER
+        );
         member.assignCompany(companyId);
         return member;
     }

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -64,7 +64,6 @@ public class Member extends BaseEntity {
      * 개인 회원가입
      * */
     public static Member signUpIndividual(MemberSignUpRequest request) {
-        System.out.println(request.email());
         return new Member(
                 request.name(),
                 new Email(request.email()),

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberInfo.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberInfo.java
@@ -1,0 +1,24 @@
+package hanieum.conik.domain.member.dto;
+
+import hanieum.conik.domain.member.Member;
+import hanieum.conik.domain.member.enumerate.MemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MemberInfo(
+        @Schema(description = "멤버 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "멤버 이름", example = "홍길동")
+        String memberName,
+
+        @Schema(description = "멤버 역할")
+        MemberRole memberRole
+) {
+    public static MemberInfo from(Member member) {
+        return new MemberInfo(
+                member.getId(),
+                member.getName(),
+                member.getRole()
+        );
+    }
+}

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberLoginRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberLoginRequest.java
@@ -1,13 +1,23 @@
 package hanieum.conik.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record MemberLoginRequest(
-        @NotBlank(message = "이메일은 필수 입력입니다.")
-        @Email(message = "유효한 이메일 형식이어야 합니다.")
+        @Schema(description = "이메일", example = "kjeng7897@gmail.com")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
         String email,
 
-        @NotBlank(message = "비밀번호는 필수 입력입니다.")
+        @Schema(description = "비밀번호", example = "7897")
+        @NotBlank(message = "비밀번호는 필수입니다.")
         String password
-) {}
+) {
+        public static MemberLoginRequest from(MemberSignUpRequest signUpRequest) {
+                return new MemberLoginRequest(
+                        signUpRequest.email(),
+                        signUpRequest.password()
+                );
+        }
+}

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberLoginResponse.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberLoginResponse.java
@@ -1,9 +1,11 @@
 package hanieum.conik.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MemberLoginResponse(
-        String accessToken,
+        @Schema(description = "토큰 정보")
+        TokenInfo tokenInfo,
 
-        String refreshToken,
-
-        Long memberId
+        @Schema(description = "멤버 정보")
+        MemberInfo memberInfo
 ) { }

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberSignUpRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberSignUpRequest.java
@@ -1,21 +1,39 @@
 package hanieum.conik.domain.member.dto;
 
-import hanieum.conik.domain.member.enumerate.MemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record MemberSignUpRequest(
-        @NotBlank(message = "이메일은 필수 입력입니다.")
-        @Email(message = "유효한 이메일 형식이어야 합니다.")
+        @Schema(description = "사용자 이름", example = "정성호")
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @Schema(description = "이메일", example = "kjeng7897@gmail.com")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
         String email,
 
-        @NotBlank(message = "비밀번호는 필수 입력입니다.")
+        @Schema(description = "비밀번호", example = "7897")
+        @NotBlank(message = "비밀번호는 필수입니다.")
         String password,
 
-        @NotBlank(message = "전화번호는 필수 입력입니다.")
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        @NotBlank(message = "전화번호는 필수입니다.")
         String phoneNumber,
 
-        @NotNull(message = "약관 동의 여부를 선택해주세요.")
+        @Schema(description = "서비스 이용약관 동의 여부")
+        @NotNull(message = "서비스 이용약관 동의는 필수입니다.")
         Boolean termsOfServiceAgreed
-) {}
+) {
+        public MemberSignUpRequest withHashedPassword(String hashedPassword) {
+                return new MemberSignUpRequest(
+                        this.name,
+                        this.email,
+                        hashedPassword,
+                        this.phoneNumber,
+                        this.termsOfServiceAgreed
+                );
+        }
+}

--- a/src/main/java/hanieum/conik/domain/member/dto/TokenInfo.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/TokenInfo.java
@@ -1,0 +1,15 @@
+package hanieum.conik.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenInfo(
+        @Schema(description = "액세스 토큰")
+        String accessToken,
+
+        @Schema(description = "리프레시 토큰")
+        String refreshToken
+) {
+    public static TokenInfo of(String accessToken, String refreshToken) {
+        return new TokenInfo(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/hanieum/conik/domain/member/shared/Email.java
+++ b/src/main/java/hanieum/conik/domain/member/shared/Email.java
@@ -2,7 +2,6 @@ package hanieum.conik.domain.member.shared;
 
 import hanieum.conik.domain.member.exception.MemberErrorType;
 import hanieum.conik.domain.member.exception.MemberException;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.regex.Pattern;
 

--- a/src/main/java/hanieum/conik/domain/member/shared/Email.java
+++ b/src/main/java/hanieum/conik/domain/member/shared/Email.java
@@ -2,17 +2,20 @@ package hanieum.conik.domain.member.shared;
 
 import hanieum.conik.domain.member.exception.MemberErrorType;
 import hanieum.conik.domain.member.exception.MemberException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.regex.Pattern;
 
 /**
  * 이메일 값 객체
  */
+@Slf4j
 public record Email(String address) {
     private static final Pattern EMAIL_PATTERN =
             Pattern.compile("^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$");
 
     public Email {
+        log.info("Email record created with address: {}", address);
         if (!EMAIL_PATTERN.matcher(address).matches()) {
             throw new MemberException(MemberErrorType.INVALID_EMAIL);
         }

--- a/src/main/java/hanieum/conik/domain/member/shared/Email.java
+++ b/src/main/java/hanieum/conik/domain/member/shared/Email.java
@@ -9,13 +9,11 @@ import java.util.regex.Pattern;
 /**
  * 이메일 값 객체
  */
-@Slf4j
 public record Email(String address) {
     private static final Pattern EMAIL_PATTERN =
             Pattern.compile("^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$");
 
     public Email {
-        log.info("Email record created with address: {}", address);
         if (!EMAIL_PATTERN.matcher(address).matches()) {
             throw new MemberException(MemberErrorType.INVALID_EMAIL);
         }

--- a/src/main/java/hanieum/conik/domain/project/entity/Project.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/Project.java
@@ -119,12 +119,15 @@ public class Project extends AbstractEntity {
     }
 
     public void addDrawing(ProjectDrawingFile drawingFile) {
-        this.drawingFiles.add(drawingFile);
-        drawingFile.updateProject(this);
+        if (!this.drawingFiles.contains(drawingFile)) {
+            this.drawingFiles.add(drawingFile);
+            drawingFile.updateProject(this);
+        }
     }
 
     public void removeDrawing(ProjectDrawingFile drawingFile) {
         this.drawingFiles.remove(drawingFile);
+        drawingFile.updateProject(null);
     }
 
     public void finalizeDrawingFiles() {

--- a/src/main/java/hanieum/conik/domain/project/entity/Project.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/Project.java
@@ -109,6 +109,8 @@ public class Project extends AbstractEntity {
         this.canPhoneConsult = request.canPhoneConsult();
         this.deliveryAddress = request.deliveryAddress();
         this.submitStatus = request.submitStatus();
+
+        finalizeDrawingFiles();
     }
 
     public void updateBidStatusAndPublicUntil(BidStatusUpdateRequest bidStatusUpdateRequest) {
@@ -123,5 +125,9 @@ public class Project extends AbstractEntity {
 
     public void removeDrawing(ProjectDrawingFile drawingFile) {
         this.drawingFiles.remove(drawingFile);
+    }
+
+    public void finalizeDrawingFiles() {
+        this.drawingFiles.forEach(ProjectDrawingFile::updateUploadStatus);
     }
 }

--- a/src/main/java/hanieum/conik/domain/project/entity/Project.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/Project.java
@@ -6,12 +6,16 @@ import hanieum.conik.domain.project.enumerate.ProjectBidStatus;
 import hanieum.conik.domain.project.enumerate.ProjectStatus;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.global.domain.AbstractEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -52,6 +56,9 @@ public class Project extends AbstractEntity {
     private SubmitStatus submitStatus = SubmitStatus.INITIALIZE;
 
     private ProjectBidStatus projectBidStatus = ProjectBidStatus.PRE_BID;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectDrawingFile> drawingFiles = new ArrayList<>();
 
     public static Project create(Long userId, String projectTitle, String category, String categoryDetail, String categoryDetailEtc,
                                  String purpose, String purposeEtc, Integer projectQuantity, String projectRequests,
@@ -107,5 +114,14 @@ public class Project extends AbstractEntity {
     public void updateBidStatusAndPublicUntil(BidStatusUpdateRequest bidStatusUpdateRequest) {
         this.projectBidStatus = bidStatusUpdateRequest.projectBidStatus();
         this.publicUntil = bidStatusUpdateRequest.publicUntil();
+    }
+
+    public void addDrawing(ProjectDrawingFile drawingFile) {
+        this.drawingFiles.add(drawingFile);
+        drawingFile.updateProject(this);
+    }
+
+    public void removeDrawing(ProjectDrawingFile drawingFile) {
+        this.drawingFiles.remove(drawingFile);
     }
 }

--- a/src/main/java/hanieum/conik/domain/project/entity/Project.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/Project.java
@@ -118,7 +118,7 @@ public class Project extends AbstractEntity {
         this.publicUntil = bidStatusUpdateRequest.publicUntil();
     }
 
-    public void addDrawing(ProjectDrawingFile drawingFile) {
+    public void addDrawing(ProjectDrawingFile drawingFile) {                                     
         if (!this.drawingFiles.contains(drawingFile)) {
             this.drawingFiles.add(drawingFile);
             drawingFile.updateProject(this);

--- a/src/main/java/hanieum/conik/domain/project/entity/ProjectDrawingFile.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/ProjectDrawingFile.java
@@ -18,8 +18,9 @@ public class ProjectDrawingFile extends AbstractEntity {
 
     private FileStatus uploadStatus;
 
-    public static ProjectDrawingFile create(ProjectDrawingUploadRequest request) {
+    public static ProjectDrawingFile create(Project project, ProjectDrawingUploadRequest request) {
         ProjectDrawingFile projectDrawingFile = new ProjectDrawingFile();
+        projectDrawingFile.project = project;
         projectDrawingFile.drawingUrl = request.drawingUrl();
         projectDrawingFile.uploadStatus = FileStatus.TEMPORARY;
         return projectDrawingFile;

--- a/src/main/java/hanieum/conik/domain/project/entity/ProjectDrawingFile.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/ProjectDrawingFile.java
@@ -3,10 +3,7 @@ package hanieum.conik.domain.project.entity;
 import hanieum.conik.adapter.project.dto.request.ProjectDrawingUploadRequest;
 import hanieum.conik.domain.project.enumerate.FileStatus;
 import hanieum.conik.global.domain.AbstractEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,19 +12,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProjectDrawingFile extends AbstractEntity {
-    @Column(nullable = false)
-    private Long projectId;
+    private Project project;
 
-    @Column(nullable = false)
     private String drawingUrl;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
     private FileStatus uploadStatus;
 
     public static ProjectDrawingFile create(ProjectDrawingUploadRequest request) {
         ProjectDrawingFile projectDrawingFile = new ProjectDrawingFile();
-        projectDrawingFile.projectId = request.projectId();
         projectDrawingFile.drawingUrl = request.drawingUrl();
         projectDrawingFile.uploadStatus = FileStatus.TEMPORARY;
         return projectDrawingFile;
@@ -35,5 +27,9 @@ public class ProjectDrawingFile extends AbstractEntity {
 
     public void updateUploadStatus() {
         this.uploadStatus = FileStatus.FINALIZED;
+    }
+
+    public void updateProject(Project project) {
+        this.project = project;
     }
 }

--- a/src/main/java/hanieum/conik/domain/project/entity/ProjectProgressPicture.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/ProjectProgressPicture.java
@@ -3,8 +3,6 @@ package hanieum.conik.domain.project.entity;
 import hanieum.conik.domain.project.enumerate.ProjectProgressStep;
 import hanieum.conik.global.domain.AbstractEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProjectPicture extends AbstractEntity {
+public class ProjectProgressPicture extends AbstractEntity {
     private Long projectProgressId;
 
     private ProjectProgressStep projectProgressStep;

--- a/src/main/resources/META-INF/Project-orm.xml
+++ b/src/main/resources/META-INF/Project-orm.xml
@@ -65,6 +65,12 @@
                 <column name="project_bid_status"/>
                 <enumerated>STRING</enumerated>
             </basic>
+
+            <one-to-many name="drawingFiles" mapped-by="project" orphan-removal="true" fetch="LAZY">
+                <cascade>
+                    <cascade-all/>
+                </cascade>
+            </one-to-many>
         </attributes>
     </entity>
 </entity-mappings>

--- a/src/main/resources/META-INF/ProjectDrawingFile-orm.xml
+++ b/src/main/resources/META-INF/ProjectDrawingFile-orm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-mappings xmlns="http://www.hibernate.org/xsd/orm/mapping"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.hibernate.org/xsd/orm/mapping
+                                     https://hibernate.org/xsd/orm/mapping/mapping-3.1.0.xsd">
+    <access>FIELD</access>
+
+    <entity class="hanieum.conik.domain.project.entity.ProjectDrawingFile" access="FIELD">
+        <table name="project_drawing_file"/>
+        <attributes>
+            <basic name="drawingUrl">
+                <column name="drawing_url" nullable="false"/>
+            </basic>
+            <basic name="uploadStatus">
+                <column name="upload_status" nullable="false"/>
+                <enumerated>STRING</enumerated>
+            </basic>
+
+            <many-to-one name="project" fetch="LAZY">
+                <join-column name="project_id" nullable="false"/>
+            </many-to-one>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/src/main/resources/META-INF/ProjectProgressPicture-orm.xml
+++ b/src/main/resources/META-INF/ProjectProgressPicture-orm.xml
@@ -5,7 +5,7 @@
                                      https://hibernate.org/xsd/orm/mapping/mapping-3.1.0.xsd">
     <access>FIELD</access>
 
-    <entity class="hanieum.conik.domain.project.entity.ProjectPicture">
+    <entity class="hanieum.conik.domain.project.entity.ProjectProgressPicture">
         <attributes>
             <basic name="projectProgressId">
                 <column name="project_progress_id"/>


### PR DESCRIPTION
## 💡 관련 이슈
- #53 

## 📝 작업 내용
Project 초기화 시 응답 구조를 개선하고, ProjectDrawingFile 엔티티와의 연관관계를 단방향으로 설정했습니다. 또한 프로젝트 저장 시 도면 파일 상태를 자동으로 업데이트하도록 구현했습니다.

## 🧑‍💻 변경 사항
- **ProjectDrawingFile 엔티티 연관관계 개선**
  - Project와 단방향 `@ManyToOne` 관계 설정
  - `updateUploadStatus()` 메서드로 파일 상태를 `FINALIZED`로 변경
  
- **ProjectModifyService 리팩토링**
  - `save()`와 `submit()` 메서드를 `saveProjectDraft()`와 `saveProjectFinal()`로 분리
  - 각 메서드에서 `SubmitStatus` 검증 로직 추가
  - 프로젝트 저장 시 연관된 도면 파일들의 상태를 자동으로 `FINALIZED`로 업데이트
  
- **ProjectQueryService 수정**
  - `INITIALIZE` 상태인 프로젝트를 조회에서 제외
  - `findProjectsWithStatus()` 메서드에서 `TEMPORARY_SAVE`와 `SUBMIT` 상태만 조회하도록 수정
  
- **ORM 매핑 파일 추가**
  - `ProjectDrawingFile-orm.xml` 생성
  - `Project-orm.xml`에 `OneToMany` 관계 추가

- **페이지네이션 적용**
  - 프로젝트 조회 API(`/v1/project/{memberId}`)와 견적서 조회 API(`/v1/proposal/{memberId}`)에 페이지네이션 기능 추가
  - `ProjectQueryService`와 `ProposalQueryService`의 반환 타입을 `List`에서 `Page`로 변경
  - Controller에 `@PageableDefault` 애노테이션 추가 (기본값: size=20, sort=createdAt, direction=DESC)

- **설정 파일 업데이트**
  - `application.yml` 파일 구성 개선 (참고: [노션 링크](https://www.notion.so/secrets-21c2f23b094f803e8f09cd8064d0360a))

## 💬 리뷰 요구사항(선택)
- ProjectDrawingFile(도면파일)과 Project(공고) 간의 단방향 매핑 설계가 비즈니스 요구사항에 적합한 지 검토해주세요