### PR TITLE
REFACTOR: 회사 정보 조회 및 Drawing file 최종 저장 로직을 구현한다

### DIFF
--- a/src/main/java/hanieum/conik/adapter/company/webapi/CompanyController.java
+++ b/src/main/java/hanieum/conik/adapter/company/webapi/CompanyController.java
@@ -1,5 +1,7 @@
 package hanieum.conik.adapter.company.webapi;
 
+import hanieum.conik.adapter.company.webapi.response.CompanyDetailResponse;
+import hanieum.conik.adapter.company.webapi.response.CompanyResponse;
 import hanieum.conik.application.company.provided.CompanyFinder;
 import hanieum.conik.application.company.provided.CompanyRegister;
 import hanieum.conik.domain.company.Company;
@@ -46,7 +48,8 @@ public class CompanyController {
     - 기업id를 통해 특정 기업을 조회할 수 있습니다.
     """)
     @GetMapping("/{companyId}")
-    public ApiResponse<Company> findCompany(@PathVariable Long companyId) {
-        return ApiResponse.success(companyFinder.findCompany(companyId));
+    public ApiResponse<CompanyResponse> findCompany(@PathVariable Long companyId) {
+        Company company = companyFinder.findCompanyWithAddresses(companyId);
+        return ApiResponse.success(CompanyResponse.from(company));
     }
 }

--- a/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyAddressResponse.java
+++ b/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyAddressResponse.java
@@ -1,0 +1,19 @@
+package hanieum.conik.adapter.company.webapi.response;
+
+import hanieum.conik.domain.company.CompanyAddress;
+
+public record CompanyAddressResponse(
+        String postal,
+
+        String street,
+
+        String detail
+) {
+    public static CompanyAddressResponse from(CompanyAddress address) {
+        return new CompanyAddressResponse(
+                address.getAddressPostalCode(),
+                address.getAddressStreetAddress(),
+                address.getAddressDetailAddress()
+        );
+    }
+}

--- a/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyDetailResponse.java
+++ b/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyDetailResponse.java
@@ -1,0 +1,47 @@
+package hanieum.conik.adapter.company.webapi.response;
+
+import hanieum.conik.domain.company.Company;
+import hanieum.conik.domain.company.enumerate.CompanyStatus;
+
+public record CompanyDetailResponse(
+        Long id,
+
+        String name,
+
+        String owner,
+
+        String email,
+
+        String phoneNumber,
+
+        String businessType,
+
+        String industry,
+
+        String registrationNumber,
+
+        String registrationCertificateUrl,
+
+        String bankbookCopy,
+
+        String profileUrl,
+
+        CompanyStatus status
+) {
+    public static CompanyDetailResponse from(Company company) {
+        return new CompanyDetailResponse(
+                company.getId(),
+                company.getName(),
+                company.getOwner(),
+                company.getEmail().address(),
+                company.getPhoneNumber(),
+                company.getBusinessType(),
+                company.getIndustry(),
+                company.getRegistrationNumber(),
+                company.getRegistrationCertificateUrl(),
+                company.getBankbookCopy(),
+                company.getProfileUrl(),
+                company.getStatus()
+        );
+    }
+}

--- a/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyResponse.java
+++ b/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyResponse.java
@@ -11,9 +11,11 @@ public record CompanyResponse(
 ) {
     public static CompanyResponse from(Company company) {
         CompanyDetailResponse detail = CompanyDetailResponse.from(company);
-        List<CompanyAddressResponse> addresses = company.getAddresses().stream()
-                .map(CompanyAddressResponse::from)
-                .toList();
+        List<CompanyAddressResponse> addresses = company.getAddresses() == null
+                ? List.of()
+                : company.getAddresses().stream()
+                    .map(CompanyAddressResponse::from)
+                    .toList();
 
         return new CompanyResponse(detail, addresses);
     }

--- a/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyResponse.java
+++ b/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyResponse.java
@@ -1,0 +1,20 @@
+package hanieum.conik.adapter.company.webapi.response;
+
+import hanieum.conik.domain.company.Company;
+
+import java.util.List;
+
+public record CompanyResponse(
+        CompanyDetailResponse detail,
+
+        List<CompanyAddressResponse> addresses
+) {
+    public static CompanyResponse from(Company company) {
+        CompanyDetailResponse detail = CompanyDetailResponse.from(company);
+        List<CompanyAddressResponse> addresses = company.getAddresses().stream()
+                .map(CompanyAddressResponse::from)
+                .toList();
+
+        return new CompanyResponse(detail, addresses);
+    }
+}

--- a/src/main/java/hanieum/conik/adapter/project/dto/response/MemberProjectQueryResponse.java
+++ b/src/main/java/hanieum/conik/adapter/project/dto/response/MemberProjectQueryResponse.java
@@ -21,14 +21,7 @@ public record MemberProjectQueryResponse(
         @Schema(description = "프로젝트 도면 파일 목록")
         List<String> drawingUrls
 ) {
-    public static MemberProjectQueryResponse from(Long projectId, LocalDateTime modifiedAt, ProjectRegisterRequest projectRegisterRequest, List<ProjectDrawingFile> drawingFiles) {
-        List<String> drawingUrls = drawingFiles.stream()
-                .map(ProjectDrawingFile::getDrawingUrl)
-                .toList();
-        return new MemberProjectQueryResponse(projectId, modifiedAt, projectRegisterRequest, drawingUrls);
-    }
-
-    public static MemberProjectQueryResponse of(Project project){
+    public static MemberProjectQueryResponse from(Project project){
         return new MemberProjectQueryResponse(
                 project.getId(),
                 project.getModifiedAt(),

--- a/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
+++ b/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
@@ -7,6 +7,7 @@ import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
 import hanieum.conik.application.project.provided.ProjectDrawingSaver;
 import hanieum.conik.application.project.provided.ProjectFinder;
 import hanieum.conik.application.project.provided.ProjectSaver;
+import hanieum.conik.domain.project.entity.Project;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.global.adapter.security.AuthSourceType;
 import hanieum.conik.global.adapter.security.AuthorizeUser;
@@ -43,7 +44,9 @@ public class ProjectController {
     @PostMapping("{memberId}/init")
     @AuthorizeUser(sourceType = AuthSourceType.PATH_VARIABLE, paramName = "memberId")
     public ApiResponse<MemberProjectQueryResponse> initProject(@PathVariable("memberId") Long memberId) {
-        return ApiResponse.success(projectSaver.initiate(memberId));
+        Project project = projectSaver.initiate(memberId);
+
+        return ApiResponse.success(MemberProjectQueryResponse.from(project));
     }
 
     @Operation(summary = "프로젝트(공고) 수정 및 임시저장 API", description = "임시 저장 시, 발급된 프로젝트(공고)에 대해 정보를 수정합니다.")
@@ -51,7 +54,9 @@ public class ProjectController {
     @AuthorizeUser(sourceType = AuthSourceType.REQUEST_BODY, fieldName = "memberId")
     public ApiResponse<MemberProjectQueryResponse> saveProjectTemp(@PathVariable("projectId") Long projectId,
                                                                @RequestBody ProjectRegisterRequest projectRegisterRequest) {
-        return ApiResponse.success(projectSaver.saveProjectDraft(projectId, projectRegisterRequest));
+        Project project = projectSaver.saveProjectDraft(projectId, projectRegisterRequest);
+
+        return ApiResponse.success(MemberProjectQueryResponse.from(project));
     }
 
     @Operation(summary = "프로젝트(공고) 수정 및 저장 API", description = "작성 완료 된 프로젝트(공고)를 최종 저장합니다.")
@@ -59,7 +64,9 @@ public class ProjectController {
     @AuthorizeUser(sourceType = AuthSourceType.REQUEST_BODY, fieldName = "memberId")
     public ApiResponse<MemberProjectQueryResponse> saveProjectFinal(@PathVariable("projectId") Long projectId,
                                                                 @RequestBody @Valid ProjectRegisterRequest projectRegisterRequest) {
-        return ApiResponse.success(projectSaver.saveProjectFinal(projectId, projectRegisterRequest));
+        Project project = projectSaver.saveProjectFinal(projectId, projectRegisterRequest);
+
+        return ApiResponse.success(MemberProjectQueryResponse.from(project));
     }
 
     @Operation(summary = "사용자 프로젝트(공고) 조회 API", description = "사용자의 프로젝트(공고) 목록을 조회합니다.")
@@ -67,7 +74,9 @@ public class ProjectController {
     public ApiResponse<Page<MemberProjectQueryResponse>> getMemberProjects(@RequestParam(value = "status", required = false) SubmitStatus submitStatus,
                                                                            @RequestParam(value = "memberId", required = false) Long memberId,
                                                                            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.success(projectFinder.getMemberProjects(memberId, submitStatus, pageable));
+        Page<Project> projects = projectFinder.getMemberProjects(memberId, submitStatus, pageable);
+
+        return ApiResponse.success(projects.map(MemberProjectQueryResponse::from));
     }
 
     @Operation(summary = "특정 프로젝트(공고) 조회 API", description = "프로젝트 ID로 특정 프로젝트를 조회합니다.")
@@ -75,7 +84,9 @@ public class ProjectController {
     @AuthorizeUser(sourceType = AuthSourceType.REQUEST_PARAM, paramName = "memberId")
     public ApiResponse<MemberProjectQueryResponse> getProject(@PathVariable("projectId") Long projectId,
                                                               @RequestParam("memberId") Long memberId) {
-        return ApiResponse.success(projectFinder.getProjectDetail(projectId, memberId));
+        Project project = projectFinder.getProjectDetail(projectId, memberId);
+
+        return ApiResponse.success(MemberProjectQueryResponse.from(project));
     }
 
     @Operation(summary = "프로젝트(공고) 입찰 상태 변경 API", description = "프로젝트(공고)의 입찰 상태를 변경합니다.")
@@ -83,6 +94,8 @@ public class ProjectController {
     @AuthorizeUser(sourceType = AuthSourceType.REQUEST_BODY, fieldName = "memberId")
     public ApiResponse<MemberProjectQueryResponse> changeProjectStatus(@PathVariable("projectId") Long projectId,
                                                                        @RequestBody @Valid  BidStatusUpdateRequest bidStatusUpdateRequest) {
-        return ApiResponse.success(projectSaver.updateProjectBidStatus(projectId, bidStatusUpdateRequest));
+        Project project = projectSaver.updateProjectBidStatus(projectId, bidStatusUpdateRequest);
+
+        return ApiResponse.success(MemberProjectQueryResponse.from(project));
     }
 }

--- a/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalResponse.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalResponse.java
@@ -5,6 +5,7 @@ import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 public record ProposalResponse(
     @Schema(description = "기업 견적서 PK", example = "1")
@@ -17,6 +18,7 @@ public record ProposalResponse(
     ProposalRegisterRequest proposalRegisterRequest
 ) {
     public static ProposalResponse from(Proposal proposal) {
+        Objects.requireNonNull(proposal, "proposal must not be null");
         return new ProposalResponse(
                 proposal.getId(),
                 proposal.getModifiedAt(),

--- a/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalResponse.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalResponse.java
@@ -1,6 +1,7 @@
 package hanieum.conik.adapter.proposal.dto.response;
 
 import hanieum.conik.adapter.proposal.dto.request.ProposalRegisterRequest;
+import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -15,8 +16,12 @@ public record ProposalResponse(
     @Schema(description = "기업 견적서 상세 내용")
     ProposalRegisterRequest proposalRegisterRequest
 ) {
-    public static ProposalResponse from(Long proposalId, LocalDateTime modifiedAt, ProposalRegisterRequest proposalRegisterRequest) {
-        return new ProposalResponse(proposalId, modifiedAt, proposalRegisterRequest);
+    public static ProposalResponse from(Proposal proposal) {
+        return new ProposalResponse(
+                proposal.getId(),
+                proposal.getModifiedAt(),
+                ProposalRegisterRequest.from(proposal)
+        );
     }
 }
 

--- a/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
@@ -8,6 +8,7 @@ import hanieum.conik.application.proposal.provided.ProposalDrawingSaver;
 import hanieum.conik.application.proposal.provided.ProposalFinder;
 import hanieum.conik.application.proposal.provided.ProposalSaver;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
+import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import hanieum.conik.domain.proposal.domain.enumerate.ProposalBidStatus;
 import hanieum.conik.global.adapter.security.AuthSourceType;
 import hanieum.conik.global.adapter.security.AuthorizeUser;
@@ -44,21 +45,26 @@ public class ProposalController {
     @PostMapping("/{projectId}/{memberId}/init")
     public ApiResponse<ProposalResponse> initProposal(@PathVariable("memberId") Long memberId,
                                                       @PathVariable("projectId") Long projectId) {
-        return ApiResponse.success(proposalSaver.initiate(memberId, projectId));
+        Proposal proposal =  proposalSaver.initiate(memberId, projectId);
+
+        return ApiResponse.success(ProposalResponse.from(proposal));
     }
 
     @Operation(summary = "기업 견적서(입찰) 수정 및 임시저장 API", description = "임시 저장 시, 발급된 기업 견적서(입찰)에 대해 정보를 수정합니다.")
     @PostMapping("{proposalId}/draft")
     public ApiResponse<ProposalResponse> saveProjectTemp(@PathVariable("proposalId") Long proposalId,
                                                          @RequestBody ProposalRegisterRequest proposalRegisterRequest) {
-        return ApiResponse.success(proposalSaver.saveProposalDraft(proposalId, proposalRegisterRequest));
+        Proposal proposal = proposalSaver.saveProposalDraft(proposalId, proposalRegisterRequest);
+        return ApiResponse.success(ProposalResponse.from(proposal));
     }
 
     @Operation(summary = "기업 견적서(입찰) 수정 및 저장 API", description = "작성 완료 된 기업 견적서(입찰)를 최종 저장합니다.")
     @PostMapping("{proposalId}/final")
     public ApiResponse<ProposalResponse> saveProjectFinal(@PathVariable("proposalId") Long proposalId,
                                                           @RequestBody @Valid ProposalRegisterRequest proposalRegisterRequest) {
-        return ApiResponse.success(proposalSaver.saveProposalFinal(proposalId, proposalRegisterRequest));
+
+        Proposal proposal = proposalSaver.saveProposalFinal(proposalId, proposalRegisterRequest);
+        return ApiResponse.success(ProposalResponse.from(proposal));
     }
 
     @Operation(summary = "프로젝트별 기업 견적서(입찰) 조회 API", description = "기업 견적서(입찰) 목록을 조회합니다.")
@@ -68,14 +74,18 @@ public class ProposalController {
                                                                          @RequestParam(required = false) SubmitStatus status,
                                                                          @RequestParam(required = false) Long projectId,
                                                                          @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.success(proposalFinder.getCompanyProposals(memberId, projectId, status, pageable)) ;
+        Page<Proposal> proposals = proposalFinder.getCompanyProposals(memberId, projectId, status, pageable);
+
+        return ApiResponse.success(proposals.map(ProposalDetailResponse::from));
     }
 
 
     @Operation(summary = "기업 견적서(입찰) 단일 조회 API", description = "특정 기업 견적서(입찰)를 조회합니다.")
     @GetMapping("/{proposalId}/detail")
     public ApiResponse<ProposalDetailResponse> getProposal(@PathVariable("proposalId") Long proposalId) {
-        return ApiResponse.success(proposalFinder.getProposalDetail(proposalId));
+        Proposal proposal = proposalFinder.getProposalDetail(proposalId);
+
+        return ApiResponse.success(ProposalDetailResponse.from(proposal) ) ;
     }
 
 
@@ -83,20 +93,26 @@ public class ProposalController {
     @PatchMapping("/{proposalId}/request")
     public ApiResponse<ProposalResponse> requestDeal(@PathVariable("proposalId") Long proposalId,
                                                      @RequestParam(required = false) ProposalBidStatus proposalBidStatus) {
-        return ApiResponse.success(proposalSaver.updateToDealRequested(proposalId, proposalBidStatus));
+        Proposal proposal = proposalSaver.updateToDealRequested(proposalId, proposalBidStatus);
+
+        return ApiResponse.success(ProposalResponse.from(proposal));
     }
 
     @Operation(summary = "요청된 거래를 수락합니다.", description = "입찰에 참여한 기업 중에 골라서 거래를 요청합니다.")
     @PatchMapping("/{proposalId}/accept")
     public ApiResponse<ProposalResponse> acceptDeal(@PathVariable("proposalId") Long proposalId,
                                                     @RequestParam(required = false) ProposalBidStatus proposalBidStatus) {
-        return ApiResponse.success(proposalSaver.AcceptDeal(proposalId, proposalBidStatus));
+        Proposal proposal = proposalSaver.AcceptDeal(proposalId, proposalBidStatus);
+
+        return ApiResponse.success(ProposalResponse.from(proposal));
     }
 
     @Operation(summary = "요청된 거래를 거절합니다.", description = "입찰한 견적서에 대해 수신한 거래 요청을 거절합니다.")
     @PatchMapping("/{proposalId}/reject")
     public ApiResponse<ProposalResponse> rejectDeal(@PathVariable("proposalId") Long proposalId,
                                                     @RequestParam(required = false) ProposalBidStatus proposalBidStatus) {
-        return ApiResponse.success(proposalSaver.RejectDeal(proposalId, proposalBidStatus));
+        Proposal proposal = proposalSaver.RejectDeal(proposalId, proposalBidStatus);
+
+        return ApiResponse.success(ProposalResponse.from(proposal));
     }
 }

--- a/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
@@ -91,9 +91,8 @@ public class ProposalController {
 
     @Operation(summary = "기업 견적서(입찰) 요청 API", description = "입찰에 참여한 기업 중에 골라서 거래를 요청합니다.")
     @PatchMapping("/{proposalId}/request")
-    public ApiResponse<ProposalResponse> requestDeal(@PathVariable("proposalId") Long proposalId,
-                                                     @RequestParam(required = false) ProposalBidStatus proposalBidStatus) {
-        Proposal proposal = proposalSaver.updateToDealRequested(proposalId, proposalBidStatus);
+    public ApiResponse<ProposalResponse> dealRequest(@PathVariable("proposalId") Long proposalId) {
+        Proposal proposal = proposalSaver.updateToDealRequested(proposalId);
 
         return ApiResponse.success(ProposalResponse.from(proposal));
     }

--- a/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
@@ -102,7 +102,7 @@ public class ProposalController {
     @PatchMapping("/{proposalId}/accept")
     public ApiResponse<ProposalResponse> acceptDeal(@PathVariable("proposalId") Long proposalId,
                                                     @RequestParam(required = false) ProposalBidStatus proposalBidStatus) {
-        Proposal proposal = proposalSaver.AcceptDeal(proposalId, proposalBidStatus);
+        Proposal proposal = proposalSaver.acceptDeal(proposalId, proposalBidStatus);
 
         return ApiResponse.success(ProposalResponse.from(proposal));
     }
@@ -111,7 +111,7 @@ public class ProposalController {
     @PatchMapping("/{proposalId}/reject")
     public ApiResponse<ProposalResponse> rejectDeal(@PathVariable("proposalId") Long proposalId,
                                                     @RequestParam(required = false) ProposalBidStatus proposalBidStatus) {
-        Proposal proposal = proposalSaver.RejectDeal(proposalId, proposalBidStatus);
+        Proposal proposal = proposalSaver.rejectDeal(proposalId, proposalBidStatus);
 
         return ApiResponse.success(ProposalResponse.from(proposal));
     }

--- a/src/main/java/hanieum/conik/application/company/CompanyService.java
+++ b/src/main/java/hanieum/conik/application/company/CompanyService.java
@@ -7,9 +7,6 @@ import hanieum.conik.domain.company.Company;
 import hanieum.conik.domain.company.dto.CompanyRegisterRequest;
 import hanieum.conik.domain.company.exception.CompanyErrorType;
 import hanieum.conik.domain.company.exception.CompanyException;
-import hanieum.conik.domain.member.shared.Email;
-import hanieum.conik.global.adapter.s3.dto.ImageUploadRequest;
-import hanieum.conik.global.adapter.s3.dto.ReadPreSignedUrlResponse;
 import hanieum.conik.global.application.required.BucketClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +36,12 @@ public class CompanyService implements CompanyFinder, CompanyRegister {
     @Transactional(readOnly = true)
     public Company findCompany(Long companyId) {
         return companyRepository.findById(companyId)
+                .orElseThrow(() -> new CompanyException(CompanyErrorType.COMPANY_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public Company findCompanyWithAddresses(Long companyId) {
+        return companyRepository.findByIdWithAddresses(companyId)
                 .orElseThrow(() -> new CompanyException(CompanyErrorType.COMPANY_NOT_FOUND));
     }
 

--- a/src/main/java/hanieum/conik/application/company/provided/CompanyFinder.java
+++ b/src/main/java/hanieum/conik/application/company/provided/CompanyFinder.java
@@ -9,5 +9,8 @@ import java.util.List;
  */
 public interface CompanyFinder {
     List<Company> findAllCompanies();
+
     Company findCompany(Long companyId);
+
+    Company findCompanyWithAddresses(Long companyId);
 }

--- a/src/main/java/hanieum/conik/application/company/required/CompanyRepository.java
+++ b/src/main/java/hanieum/conik/application/company/required/CompanyRepository.java
@@ -2,6 +2,12 @@ package hanieum.conik.application.company.required;
 
 import hanieum.conik.domain.company.Company;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
+    @Query("SELECT c FROM Company c LEFT JOIN FETCH c.addresses WHERE c.id = :id")
+    Optional<Company> findByIdWithAddresses(@Param("id") Long id);
 }

--- a/src/main/java/hanieum/conik/application/project/ProjectDrawingModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectDrawingModifyService.java
@@ -36,11 +36,5 @@ public class ProjectDrawingModifyService implements ProjectDrawingSaver {
              throw new ProjectException(ProjectErrorType.PROJECT_DRAWING_SAVE_ERROR);
          }
      }
-
-     @Override
-     public void updateDrawingFileToFinal(ProjectDrawingUploadRequest projectDrawingUploadRequest) {
-         List<ProjectDrawingFile> drawingFiles = projectDrawingFinder.findProjectDrawingFiles(projectDrawingUploadRequest.projectId());
-         drawingFiles.forEach(ProjectDrawingFile::updateUploadStatus);
-     }
 }
 

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -36,7 +36,7 @@ public class ProjectModifyService implements ProjectSaver {
 
     @Override
     public Project saveProjectDraft(Long projectId, ProjectRegisterRequest request) {
-        if (!request.submitStatus().equals(SubmitStatus.TEMPORARY_SAVE)) {
+        if (request.submitStatus() != SubmitStatus.TEMPORARY_SAVE) {
             throw new ProjectException(ProjectErrorType.PROJECT_DRAFT_SAVE_ERROR);
         }
         return getSavedProject(projectId, request);
@@ -44,7 +44,7 @@ public class ProjectModifyService implements ProjectSaver {
 
     @Override
     public Project saveProjectFinal(Long projectId, ProjectRegisterRequest request) {
-        if (!request.submitStatus().equals(SubmitStatus.SUBMIT)) {
+        if (request.submitStatus() != SubmitStatus.SUBMIT) {
             throw new ProjectException(ProjectErrorType.PROJECT_FINAL_SAVE_ERROR);
         }
         return getSavedProject(projectId, request);
@@ -55,7 +55,7 @@ public class ProjectModifyService implements ProjectSaver {
         try {
             Project project = projectFinder.findProject(projectId);
             project.updateBidStatusAndPublicUntil(bidStatusUpdateRequest);
-            projectRepository.save(project);
+
             return projectRepository.save(project);
         } catch (Exception e) {
             log.error("에러 발생", e);

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -25,18 +25,17 @@ public class ProjectModifyService implements ProjectSaver {
     private final ProjectFinder projectFinder;
 
     @Override
-    public MemberProjectQueryResponse initiate(Long memberId) {
+    public Project initiate(Long memberId) {
         try {
             Project project = Project.initiate(memberId);
-            projectRepository.save(project);
-            return MemberProjectQueryResponse.from(project.getId(), project.getModifiedAt(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
+            return projectRepository.save(project);
         } catch (Exception e) {
             throw new ProjectException(ProjectErrorType.PROJECT_INITIATE_ERROR);
         }
     }
 
     @Override
-    public MemberProjectQueryResponse saveProjectDraft(Long projectId, ProjectRegisterRequest request) {
+    public Project saveProjectDraft(Long projectId, ProjectRegisterRequest request) {
         if (!request.submitStatus().equals(SubmitStatus.TEMPORARY_SAVE)) {
             throw new ProjectException(ProjectErrorType.PROJECT_DRAFT_SAVE_ERROR);
         }
@@ -44,7 +43,7 @@ public class ProjectModifyService implements ProjectSaver {
     }
 
     @Override
-    public MemberProjectQueryResponse saveProjectFinal(Long projectId, ProjectRegisterRequest request) {
+    public Project saveProjectFinal(Long projectId, ProjectRegisterRequest request) {
         if (!request.submitStatus().equals(SubmitStatus.SUBMIT)) {
             throw new ProjectException(ProjectErrorType.PROJECT_FINAL_SAVE_ERROR);
         }
@@ -52,19 +51,19 @@ public class ProjectModifyService implements ProjectSaver {
     }
 
     @Override
-    public MemberProjectQueryResponse updateProjectBidStatus(Long projectId, BidStatusUpdateRequest bidStatusUpdateRequest) {
+    public Project updateProjectBidStatus(Long projectId, BidStatusUpdateRequest bidStatusUpdateRequest) {
         try {
             Project project = projectFinder.findProject(projectId);
             project.updateBidStatusAndPublicUntil(bidStatusUpdateRequest);
             projectRepository.save(project);
-            return MemberProjectQueryResponse.from(project.getId(), project.getModifiedAt(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
+            return projectRepository.save(project);
         } catch (Exception e) {
             log.error("에러 발생", e);
             throw new ProjectException(ProjectErrorType.PROJECT_BID_STATUS_UPDATE_ERROR);
         }
     }
 
-    private MemberProjectQueryResponse getSavedProject(Long projectId, ProjectRegisterRequest request) {
+    private Project getSavedProject(Long projectId, ProjectRegisterRequest request) {
         try {
             Project project = projectFinder.findProject(projectId);
             project.update(request);
@@ -73,7 +72,7 @@ public class ProjectModifyService implements ProjectSaver {
 
             projectRepository.save(project);
 
-            return MemberProjectQueryResponse.from(projectId, project.getModifiedAt(), ProjectRegisterRequest.from(project), project.getDrawingFiles());
+            return projectRepository.save(project);
         } catch (Exception e) {
             log.error("에러 발생", e);
             throw new ProjectException(ProjectErrorType.PROJECT_SAVE_ERROR);

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -69,7 +69,7 @@ public class ProjectModifyService implements ProjectSaver {
             Project project = projectFinder.findProject(projectId);
             project.update(request);
 
-            project.getDrawingFiles().forEach(ProjectDrawingFile::updateUploadStatus);
+            project.finalizeDrawingFiles();
 
             projectRepository.save(project);
 

--- a/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
@@ -30,21 +30,13 @@ public class ProjectQueryService implements ProjectFinder {
     }
 
     @Override
-    public Page<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable) {
-        Page<Project> projects;
+    public Page<Project> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable) {
 
         if (memberId != null) {
-            projects = findProjectsWithStatus(submitStatus, memberId, pageable);
+            return findProjectsWithStatus(submitStatus, memberId, pageable);
         } else {
-            projects = findAllProjectsWithStatus(submitStatus, pageable);
+            return findAllProjectsWithStatus(submitStatus, pageable);
         }
-
-        return projects.map(project -> MemberProjectQueryResponse.from(
-                        project.getId(),
-                        project.getModifiedAt(),
-                        ProjectRegisterRequest.from(project),
-                        project.getDrawingFiles()
-                ));
     }
 
     private Page<Project> findProjectsWithStatus(SubmitStatus submitStatus, Long memberId, Pageable pageable) {
@@ -69,7 +61,7 @@ public class ProjectQueryService implements ProjectFinder {
     }
 
     @Override
-    public MemberProjectQueryResponse getProjectDetail(Long projectId, Long memberId){
-        return MemberProjectQueryResponse.of(findProject(projectId));
+    public Project getProjectDetail(Long projectId, Long memberId){
+        return findProject(projectId);
     }
 }

--- a/src/main/java/hanieum/conik/application/project/provided/ProjectDrawingSaver.java
+++ b/src/main/java/hanieum/conik/application/project/provided/ProjectDrawingSaver.java
@@ -4,6 +4,4 @@ import hanieum.conik.adapter.project.dto.request.ProjectDrawingUploadRequest;
 
 public interface ProjectDrawingSaver {
     void saveDrawingFileTemp(ProjectDrawingUploadRequest projectDrawingUploadRequest);
-
-    void updateDrawingFileToFinal(ProjectDrawingUploadRequest projectDrawingUploadRequest);
 }

--- a/src/main/java/hanieum/conik/application/project/provided/ProjectFinder.java
+++ b/src/main/java/hanieum/conik/application/project/provided/ProjectFinder.java
@@ -11,7 +11,7 @@ public interface ProjectFinder {
 
     Project validateProjectOpenStatus(Long projectId);
 
-    MemberProjectQueryResponse getProjectDetail(Long projectId, Long memberId);
+    Project getProjectDetail(Long projectId, Long memberId);
 
-    Page<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable);
+    Page<Project> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable);
 }

--- a/src/main/java/hanieum/conik/application/project/provided/ProjectSaver.java
+++ b/src/main/java/hanieum/conik/application/project/provided/ProjectSaver.java
@@ -3,6 +3,8 @@ package hanieum.conik.application.project.provided;
 import hanieum.conik.adapter.project.dto.request.BidStatusUpdateRequest;
 import hanieum.conik.adapter.project.dto.request.ProjectRegisterRequest;
 import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
+import hanieum.conik.domain.member.Member;
+import hanieum.conik.domain.project.entity.Project;
 
 public interface ProjectSaver {
     /**
@@ -10,7 +12,7 @@ public interface ProjectSaver {
      * @param memberId 프로젝트(공고)를 작성자 ID
      * @return 생성된 프로젝트의 ID
      */
-    MemberProjectQueryResponse initiate(Long memberId);
+    Project initiate(Long memberId);
 
     /**
      * 프로젝트를 임시 저장합니다.
@@ -18,7 +20,7 @@ public interface ProjectSaver {
      * @param projectRegisterRequest 프로젝트 등록 요청 정보
      * @return 저장된 프로젝트 정보
      */
-    MemberProjectQueryResponse saveProjectDraft(Long projectId, ProjectRegisterRequest projectRegisterRequest);
+    Project saveProjectDraft(Long projectId, ProjectRegisterRequest projectRegisterRequest);
 
     /**
      * 프로젝트를 최종 저장합니다.
@@ -26,7 +28,7 @@ public interface ProjectSaver {
      * @param projectRegisterRequest 프로젝트 등록 요청 정보
      * @return 저장된 프로젝트 정보
      */
-    MemberProjectQueryResponse saveProjectFinal(Long projectId, ProjectRegisterRequest projectRegisterRequest);
+    Project saveProjectFinal(Long projectId, ProjectRegisterRequest projectRegisterRequest);
 
     /**
      * 프로젝트의 입찰 상태를 변경합니다.
@@ -34,5 +36,5 @@ public interface ProjectSaver {
      * @param bidStatusUpdateRequest 변경할 입찰 상태
      * @return 변경된 프로젝트 정보
      */
-    MemberProjectQueryResponse updateProjectBidStatus(Long projectId, BidStatusUpdateRequest bidStatusUpdateRequest);
+    Project updateProjectBidStatus(Long projectId, BidStatusUpdateRequest bidStatusUpdateRequest);
 }

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -74,7 +74,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
             Proposal proposal = proposalFinder.findProposal(proposalId);
             proposal.update(request);
 
-            proposal.finalizeDrawings();
+            proposal.finalizeDrawingFiles();
 
             Consumer<Proposal> handler = statusHandlers.get(request.submitStatus());
             handler.accept(proposal);

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -54,7 +54,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
 
     @Override
     public Proposal saveProposalDraft(Long proposalId, ProposalRegisterRequest proposalRegisterRequest) {
-        if (!proposalRegisterRequest.submitStatus().equals(SubmitStatus.TEMPORARY_SAVE)) {
+        if (!SubmitStatus.TEMPORARY_SAVE.equals(proposalRegisterRequest.submitStatus())) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DRAFT_REQUEST_ERROR);
         }
         return getSavedProposal(proposalId, proposalRegisterRequest);
@@ -62,7 +62,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
 
     @Override
     public Proposal saveProposalFinal(Long proposalId, ProposalRegisterRequest proposalRegisterRequest) {
-        if (!proposalRegisterRequest.submitStatus().equals(SubmitStatus.SUBMIT)) {
+        if (!SubmitStatus.SUBMIT.equals(proposalRegisterRequest.submitStatus())) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_FINAL_REQUEST_ERROR);
         }
         return getSavedProposal(proposalId, proposalRegisterRequest);

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -74,8 +74,6 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
             Proposal proposal = proposalFinder.findProposal(proposalId);
             proposal.update(request);
 
-            proposal.finalizeDrawingFiles();
-
             Consumer<Proposal> handler = statusHandlers.get(request.submitStatus());
             handler.accept(proposal);
 

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -93,13 +93,13 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
     }
 
     @Override
-    public Proposal updateToDealRequested(Long proposalId, ProposalBidStatus proposalBidStatus) {
-        if (!proposalBidStatus.equals(ProposalBidStatus.DEAL_REQUESTED)) {
+    public Proposal updateToDealRequested(Long proposalId) {
+        Proposal proposal = proposalFinder.findProposal(proposalId);
+        if (!proposal.getProposalBidStatus().equals(ProposalBidStatus.PRE_BID)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_REQUEST_ERROR);
         }
-        Proposal proposal = proposalFinder.findProposal(proposalId);
-        proposal.updateToBidRequested();
-        return proposal;
+
+        return proposal.updateToBidRequested();
     }
 
     @Override

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -70,7 +70,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
 
     private Proposal getSavedProposal(Long proposalId, ProposalRegisterRequest request) {
         try {
-            Proposal proposal = proposalFinder.findProposal(proposalId);
+            Proposal proposal = proposalFinder.getProposalDetail(proposalId);
             proposal.update(request);
 
             Consumer<Proposal> handler = statusHandlers.get(request.submitStatus());

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -74,6 +74,8 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
             Proposal proposal = proposalFinder.findProposal(proposalId);
             proposal.update(request);
 
+            proposal.finalizeDrawings();
+
             Consumer<Proposal> handler = statusHandlers.get(request.submitStatus());
             handler.accept(proposal);
 

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -40,21 +40,20 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
     );
 
     @Override
-    public ProposalResponse initiate(Long memberId, Long projectId) {
+    public Proposal initiate(Long memberId, Long projectId) {
         try {
             Project project = projectFinder.validateProjectOpenStatus(projectId);
 
             Proposal proposal = Proposal.initiate(memberFinder.find(memberId), project);
-            proposalRepository.save(proposal);
 
-            return ProposalResponse.from(proposal.getId(),proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
+            return proposalRepository.save(proposal);
         } catch (Exception e) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_INITIATE_ERROR);
         }
     }
 
     @Override
-    public ProposalResponse saveProposalDraft(Long proposalId, ProposalRegisterRequest proposalRegisterRequest) {
+    public Proposal saveProposalDraft(Long proposalId, ProposalRegisterRequest proposalRegisterRequest) {
         if (!proposalRegisterRequest.submitStatus().equals(SubmitStatus.TEMPORARY_SAVE)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DRAFT_REQUEST_ERROR);
         }
@@ -62,14 +61,14 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
     }
 
     @Override
-    public ProposalResponse saveProposalFinal(Long proposalId, ProposalRegisterRequest proposalRegisterRequest) {
+    public Proposal saveProposalFinal(Long proposalId, ProposalRegisterRequest proposalRegisterRequest) {
         if (!proposalRegisterRequest.submitStatus().equals(SubmitStatus.SUBMIT)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_FINAL_REQUEST_ERROR);
         }
         return getSavedProposal(proposalId, proposalRegisterRequest);
     }
 
-    private ProposalResponse getSavedProposal(Long proposalId, ProposalRegisterRequest request) {
+    private Proposal getSavedProposal(Long proposalId, ProposalRegisterRequest request) {
         try {
             Proposal proposal = proposalFinder.findProposal(proposalId);
             proposal.update(request);
@@ -77,8 +76,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
             Consumer<Proposal> handler = statusHandlers.get(request.submitStatus());
             handler.accept(proposal);
 
-            proposalRepository.save(proposal);
-            return ProposalResponse.from(proposal.getId(), proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
+            return proposal;
         } catch (Exception e) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_SAVE_ERROR);
         }
@@ -95,33 +93,33 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
     }
 
     @Override
-    public ProposalResponse updateToDealRequested(Long proposalId, ProposalBidStatus proposalBidStatus) {
+    public Proposal updateToDealRequested(Long proposalId, ProposalBidStatus proposalBidStatus) {
         if (!proposalBidStatus.equals(ProposalBidStatus.DEAL_REQUESTED)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_REQUEST_ERROR);
         }
         Proposal proposal = proposalFinder.findProposal(proposalId);
         proposal.updateToBidRequested();
-        return ProposalResponse.from(proposal.getId(), proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
+        return proposal;
     }
 
     @Override
-    public ProposalResponse AcceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
+    public Proposal AcceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
         if (!proposalBidStatus.equals(ProposalBidStatus.ACCEPT_DEAL)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_ACCEPT_ERROR);
         }
         Proposal proposal = proposalFinder.findProposal(proposalId);
         proposal.acceptDeal();
         /** 거래 상태 레코드 생성 로직 추가**/
-        return ProposalResponse.from(proposal.getId(), proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
+        return proposal;
     }
 
     @Override
-    public ProposalResponse RejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
+    public Proposal RejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
         if (!proposalBidStatus.equals(ProposalBidStatus.REJECT_DEAL)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_REJECT_ERROR);
         }
         Proposal proposal = proposalFinder.findProposal(proposalId);
         proposal.rejectDeal();
-        return ProposalResponse.from(proposal.getId(), proposal.getModifiedAt(), ProposalRegisterRequest.from(proposal));
+        return proposal;
     }
 }

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -103,7 +103,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
     }
 
     @Override
-    public Proposal AcceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
+    public Proposal acceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
         if (!proposalBidStatus.equals(ProposalBidStatus.ACCEPT_DEAL)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_ACCEPT_ERROR);
         }
@@ -114,7 +114,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
     }
 
     @Override
-    public Proposal RejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
+    public Proposal rejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
         if (!proposalBidStatus.equals(ProposalBidStatus.REJECT_DEAL)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_REJECT_ERROR);
         }

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -104,7 +104,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
 
     @Override
     public Proposal acceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
-        if (!proposalBidStatus.equals(ProposalBidStatus.ACCEPT_DEAL)) {
+        if (!ProposalBidStatus.ACCEPT_DEAL.equals(proposalBidStatus)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_ACCEPT_ERROR);
         }
         Proposal proposal = proposalFinder.findProposal(proposalId);
@@ -115,7 +115,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
 
     @Override
     public Proposal rejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus) {
-        if (!proposalBidStatus.equals(ProposalBidStatus.REJECT_DEAL)) {
+        if (!ProposalBidStatus.REJECT_DEAL.equals(proposalBidStatus)) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_REJECT_ERROR);
         }
         Proposal proposal = proposalFinder.findProposal(proposalId);

--- a/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
@@ -31,13 +31,11 @@ public class ProposalQueryService implements ProposalFinder {
     }
 
     @Override
-    public Page<ProposalDetailResponse> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus, Pageable pageable) {
+    public Page<Proposal> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus, Pageable pageable) {
         Member member = memberFinder.find(memberId);
         Long companyId = member.getCompanyId();
 
-        Page<Proposal> proposals = findProposalsWithStatus(submitStatus, companyId, projectId, pageable);
-
-        return proposals.map(ProposalDetailResponse::from);
+        return findProposalsWithStatus(submitStatus, companyId, projectId, pageable);
     }
 
     private Page<Proposal> findProposalsWithStatus(SubmitStatus submitStatus, Long companyId, Long projectId, Pageable pageable) {
@@ -53,9 +51,8 @@ public class ProposalQueryService implements ProposalFinder {
     }
 
     @Override
-    public ProposalDetailResponse getProposalDetail(Long proposalId){
-        Proposal proposal = findProposal(proposalId);
-        return ProposalDetailResponse.from(proposal);
+    public Proposal getProposalDetail(Long proposalId){
+        return findProposal(proposalId);
     }
 
 }

--- a/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
@@ -52,7 +52,7 @@ public class ProposalQueryService implements ProposalFinder {
 
     @Override
     public Proposal getProposalDetail(Long proposalId){
-        return findProposal(proposalId);
+        return proposalRepository.findDetailById(proposalId)
+                .orElseThrow(() -> new ProposalException(ProposalErrorType.PROPOSAL_NOT_FOUND));
     }
-
 }

--- a/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
+++ b/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 public interface ProposalFinder {
     Proposal findProposal(Long proposalId);
 
-    ProposalDetailResponse getProposalDetail(Long proposalId);
+    Proposal getProposalDetail(Long proposalId);
 
-    Page<ProposalDetailResponse> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus, Pageable pageable);
+    Page<Proposal> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus, Pageable pageable);
 }

--- a/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
+++ b/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
@@ -1,6 +1,5 @@
 package hanieum.conik.application.proposal.provided;
 
-import hanieum.conik.adapter.proposal.dto.response.ProposalDetailResponse;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import org.springframework.data.domain.Page;

--- a/src/main/java/hanieum/conik/application/proposal/provided/ProposalSaver.java
+++ b/src/main/java/hanieum/conik/application/proposal/provided/ProposalSaver.java
@@ -14,7 +14,7 @@ public interface ProposalSaver {
 
     Proposal updateToDealRequested(Long proposalId, ProposalBidStatus proposalBidStatus);
 
-    Proposal RejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
+    Proposal rejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
 
-    Proposal AcceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
+    Proposal acceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
 }

--- a/src/main/java/hanieum/conik/application/proposal/provided/ProposalSaver.java
+++ b/src/main/java/hanieum/conik/application/proposal/provided/ProposalSaver.java
@@ -12,7 +12,7 @@ public interface ProposalSaver {
 
     Proposal saveProposalFinal(Long proposalId, ProposalRegisterRequest proposalRegisterRequest);
 
-    Proposal updateToDealRequested(Long proposalId, ProposalBidStatus proposalBidStatus);
+    Proposal updateToDealRequested(Long proposalId);
 
     Proposal rejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
 

--- a/src/main/java/hanieum/conik/application/proposal/provided/ProposalSaver.java
+++ b/src/main/java/hanieum/conik/application/proposal/provided/ProposalSaver.java
@@ -2,18 +2,19 @@ package hanieum.conik.application.proposal.provided;
 
 import hanieum.conik.adapter.proposal.dto.request.ProposalRegisterRequest;
 import hanieum.conik.adapter.proposal.dto.response.ProposalResponse;
+import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import hanieum.conik.domain.proposal.domain.enumerate.ProposalBidStatus;
 
 public interface ProposalSaver {
-    ProposalResponse initiate(Long memberId, Long projectId);
+    Proposal initiate(Long memberId, Long projectId);
 
-    ProposalResponse saveProposalDraft(Long proposalId, ProposalRegisterRequest proposalRegisterRequest);
+    Proposal saveProposalDraft(Long proposalId, ProposalRegisterRequest proposalRegisterRequest);
 
-    ProposalResponse saveProposalFinal(Long proposalId, ProposalRegisterRequest proposalRegisterRequest);
+    Proposal saveProposalFinal(Long proposalId, ProposalRegisterRequest proposalRegisterRequest);
 
-    ProposalResponse updateToDealRequested(Long proposalId, ProposalBidStatus proposalBidStatus);
+    Proposal updateToDealRequested(Long proposalId, ProposalBidStatus proposalBidStatus);
 
-    ProposalResponse RejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
+    Proposal RejectDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
 
-    ProposalResponse AcceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
+    Proposal AcceptDeal(Long proposalId, ProposalBidStatus proposalBidStatus);
 }

--- a/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
+++ b/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
@@ -5,11 +5,18 @@ import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
-    List<Proposal> findByCompanyId(Long companyId);
+    @Query("select p from Proposal p " +
+            "left join fetch p.items " +
+            "left join fetch p.drawingFiles " +
+            "where p.id = :id")
+    Optional<Proposal> findDetailById(@Param("id") Long id);
 
     Page<Proposal> findByCompanyIdAndSubmitStatusIn(Long companyId, List<SubmitStatus> submitStatuses, Pageable pageable);
 

--- a/src/main/java/hanieum/conik/domain/company/Company.java
+++ b/src/main/java/hanieum/conik/domain/company/Company.java
@@ -23,35 +23,35 @@ public class Company extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String name;
+    private String name; // 회사 이름
 
     @Column(nullable = false)
-    private String owner;
+    private String owner;  // 대표자 이름
 
     @Embedded
     @Column(nullable = false)
-    private Email email;
+    private Email email; // 회사 이메일
 
     @Column(nullable = false)
-    private String phoneNumber;
+    private String phoneNumber; // 회사 전화
 
     @Column(nullable = false)
-    private String businessType;
+    private String businessType; // 업태
 
     @Column(nullable = false)
-    private String industry;
+    private String industry; // 종목
 
     @Column(nullable = false)
-    private String registrationNumber;
+    private String registrationNumber; // 사업자 등록번호
 
     @Column(nullable = false, length = 2048)
-    private String registrationCertificateUrl;
+    private String registrationCertificateUrl; // 사업자 등록증 URL
 
     @Column(nullable = false, length = 2048)
-    private String bankbookCopy;
+    private String bankbookCopy;  // 통장사본
 
     @Column(nullable = false, length = 2048)
-    private String profileUrl;
+    private String profileUrl; // 프로필 사진 URL
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/hanieum/conik/domain/project/entity/Project.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/Project.java
@@ -12,6 +12,7 @@ import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -57,6 +58,7 @@ public class Project extends AbstractEntity {
 
     private ProjectBidStatus projectBidStatus = ProjectBidStatus.PRE_BID;
 
+    @BatchSize( size = 250)
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectDrawingFile> drawingFiles = new ArrayList<>();
 

--- a/src/main/java/hanieum/conik/domain/project/entity/Project.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/Project.java
@@ -130,7 +130,5 @@ public class Project extends AbstractEntity {
         drawingFile.updateProject(null);
     }
 
-    public void finalizeDrawingFiles() {
-        this.drawingFiles.forEach(ProjectDrawingFile::finalizeFile);
-    }
+    public void finalizeDrawingFiles() { this.drawingFiles.forEach(ProjectDrawingFile::finalizeFile); }
 }

--- a/src/main/java/hanieum/conik/domain/project/entity/Project.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/Project.java
@@ -131,6 +131,6 @@ public class Project extends AbstractEntity {
     }
 
     public void finalizeDrawingFiles() {
-        this.drawingFiles.forEach(ProjectDrawingFile::updateUploadStatus);
+        this.drawingFiles.forEach(ProjectDrawingFile::finalizeFile);
     }
 }

--- a/src/main/java/hanieum/conik/domain/project/entity/ProjectDrawingFile.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/ProjectDrawingFile.java
@@ -26,9 +26,7 @@ public class ProjectDrawingFile extends AbstractEntity {
         return projectDrawingFile;
     }
 
-    public void updateUploadStatus() {
-        this.uploadStatus = FileStatus.FINALIZED;
-    }
+    void finalizeFile() { this.uploadStatus = FileStatus.FINALIZED; }
 
     public void updateProject(Project project) {
         this.project = project;

--- a/src/main/java/hanieum/conik/domain/project/entity/ProjectProgress.java
+++ b/src/main/java/hanieum/conik/domain/project/entity/ProjectProgress.java
@@ -4,8 +4,6 @@ import hanieum.conik.domain.project.enumerate.DeliveryStatus;
 import hanieum.conik.domain.project.enumerate.ProjectProgressStep;
 import hanieum.conik.global.domain.AbstractEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProjectProgess extends AbstractEntity {
+public class ProjectProgress extends AbstractEntity {
     private Long projectId;
 
     private ProjectProgressStep progressStep;

--- a/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
+++ b/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
@@ -72,6 +72,7 @@ public class Proposal extends AbstractEntity {
         this.drawingFiles.add(drawingFile);
         drawingFile.updateProposal(this);
     }
+    public void finalizeDrawings() { this.drawingFiles.forEach(ProposalDrawingFile::finalizeFile); }
 
     public void removeDrawing(ProposalDrawingFile drawingFile) {
         this.drawingFiles.remove(drawingFile);

--- a/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
+++ b/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
@@ -106,8 +106,9 @@ public class Proposal extends AbstractEntity {
         finalizeDrawingFiles();
     }
 
-    public void updateToBidRequested() {
+    public Proposal updateToBidRequested() {
         this.proposalBidStatus = ProposalBidStatus.DEAL_REQUESTED;
+        return this;
     }
 
     public void acceptDeal() { this.proposalBidStatus = ProposalBidStatus.ACCEPT_DEAL; }

--- a/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
+++ b/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
@@ -72,7 +72,7 @@ public class Proposal extends AbstractEntity {
         this.drawingFiles.add(drawingFile);
         drawingFile.updateProposal(this);
     }
-    public void finalizeDrawings() { this.drawingFiles.forEach(ProposalDrawingFile::finalizeFile); }
+    public void finalizeDrawingFiles() { this.drawingFiles.forEach(ProposalDrawingFile::finalizeFile); }
 
     public void removeDrawing(ProposalDrawingFile drawingFile) {
         this.drawingFiles.remove(drawingFile);

--- a/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
+++ b/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +37,10 @@ public class Proposal extends AbstractEntity {
 
     private ProposalBidStatus proposalBidStatus = ProposalBidStatus.PRE_BID;
 
+    @BatchSize(size = 250)
     private List<ProposalItem> items = new ArrayList<>();
 
+    @BatchSize(size = 250)
     private List<ProposalDrawingFile> drawingFiles = new ArrayList<>();
 
     public static Proposal create(Long projectId, Long companyId, Long totalPrice,

--- a/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
+++ b/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
@@ -72,7 +72,6 @@ public class Proposal extends AbstractEntity {
         this.drawingFiles.add(drawingFile);
         drawingFile.updateProposal(this);
     }
-    public void finalizeDrawingFiles() { this.drawingFiles.forEach(ProposalDrawingFile::finalizeFile); }
 
     public void removeDrawing(ProposalDrawingFile drawingFile) {
         this.drawingFiles.remove(drawingFile);
@@ -93,13 +92,18 @@ public class Proposal extends AbstractEntity {
             this.addItem(item);
         }
     }
+    void finalizeDrawingFiles() { this.drawingFiles.forEach(ProposalDrawingFile::finalizeFile); }
 
     public void updateToDraft() {
         this.submitStatus = SubmitStatus.TEMPORARY_SAVE;
+
+        finalizeDrawingFiles();
     }
 
     public void updateToFinal() {
         this.submitStatus = SubmitStatus.SUBMIT;
+
+        finalizeDrawingFiles();
     }
 
     public void updateToBidRequested() {

--- a/src/main/java/hanieum/conik/domain/proposal/domain/entity/ProposalDrawingFile.java
+++ b/src/main/java/hanieum/conik/domain/proposal/domain/entity/ProposalDrawingFile.java
@@ -25,7 +25,7 @@ public class ProposalDrawingFile extends AbstractEntity {
         return projectDrawingFile;
     }
 
-    public void updateUploadStatus() {
+    void finalizeFile() {
         this.uploadStatus = FileStatus.FINALIZED;
     }
 

--- a/src/main/resources/META-INF/ProjectProgress-orm.xml
+++ b/src/main/resources/META-INF/ProjectProgress-orm.xml
@@ -5,7 +5,7 @@
                                      https://hibernate.org/xsd/orm/mapping/mapping-3.1.0.xsd">
     <access>FIELD</access>
 
-    <entity class="hanieum.conik.domain.project.entity.ProjectProgess">
+    <entity class="hanieum.conik.domain.project.entity.ProjectProgress">
         <attributes>
             <basic name="projectId">
                 <column name="project_id"/>


### PR DESCRIPTION
## 💡 관련 이슈
- #65

## 📝 작업 내용
> Proposal 조회 시 응답 구조를 개선하고 관련 LazyLoading 문제를 해결했습니다.

## 🧑‍💻 변경 사항

### 1. Proposal 응답 구조 개선
- 복잡한 매개변수 분해 방식에서 `Proposal` 객체 하나만 받는 방식으로 변경
- `from(Proposal proposal)` 정적 팩토리 메소드로 통일
- 코드 가독성 및 유지보수성 향상

### 2. 레이어 책임 분리 개선
- **Service Layer**: 순수 도메인 객체(`Proposal`) 반환으로 변경
- **Controller Layer**: DTO 변환 담당으로 역할 명확화
- `ProposalFinder` 인터페이스 반환 타입을 `Page<Proposal>`로 변경
- `ProposalQueryService.getCompanyProposals()` 메소드에서 DTO 변환 로직 제거

### 3. CompanyResponse 구조 리팩토링
- `CompanyDetailResponse`와 `CompanyAddressResponse`로 분리하여 응답 구조 명확화
- 회사 정보와 주소 정보를 명확하게 분리하여 가독성 향상

### 4. LazyInitializationException 해결
- `CompanyFinder`에 `findCompanyWithAddresses()` 메소드 추가
- fetch join 구현으로 LazyLoading 문제 해결

### 5. Drawing 파일 관리 로직 통일
- `finalizeDrawingFiles()` 메소드로 일관성 있는 파일 상태 관리
- Drawing 파일 최종화 로직 통일

### 6. 코드 품질 개선
- `FileStatus` enum 문법 오류 수정 (누락된 세미콜론 추가)
- Controller에서 DTO 변환 처리로 일관된 패턴 적용
- 정적 팩토리 메소드명을 `from`으로 통일

## 💬 리뷰 요구사항(선택)
> 특별한 리뷰 요구사항 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회사 조회 시 주소 목록이 포함된 상세 응답을 제공합니다.

* **버그 수정**
  * 프로젝트 진행 상태 엔티티 오타("ProjectProgess" → "ProjectProgress")가 수정되었습니다.

* **리팩터링**
  * API 응답을 DTO로 통일해 노출 데이터를 정형화했습니다.
  * 도면 파일 최종화 처리 방식이 통일되고 접근성이 축소되어 안정성이 향상했습니다.
  * 상세 조회 시 관련 연관 데이터(주소·파일)를 한 번에 조회하도록 개선해 성능을 향상시켰습니다.

* **문서화**
  * 회사 엔티티 필드에 한글 주석이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->