### PR TITLE
REFACTOR: 공고 세부 조회 시, 입찰에 참여한 기업의 견적서 목록을 같이 반환한다 

### DIFF
--- a/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyThumbnailResponse.java
+++ b/src/main/java/hanieum/conik/adapter/company/webapi/response/CompanyThumbnailResponse.java
@@ -1,0 +1,18 @@
+package hanieum.conik.adapter.company.webapi.response;
+
+import hanieum.conik.domain.company.Company;
+
+public record CompanyThumbnailResponse(
+        Long companyId,
+
+        String companyName,
+
+        String profileUrl
+) {
+    public static CompanyThumbnailResponse from(Company company) {
+        return new CompanyThumbnailResponse(
+                company.getId(),
+                company.getName(),
+                company.getCompanyDetail().getLogoUrl()
+        );
+    }}

--- a/src/main/java/hanieum/conik/adapter/project/dto/response/MemberProjectQueryResponse.java
+++ b/src/main/java/hanieum/conik/adapter/project/dto/response/MemberProjectQueryResponse.java
@@ -22,13 +22,17 @@ public record MemberProjectQueryResponse(
         List<String> drawingUrls
 ) {
     public static MemberProjectQueryResponse from(Project project){
+        List<String> drawingUrls = (project.getDrawingFiles() != null)
+                ? project.getDrawingFiles().stream()
+                .map(ProjectDrawingFile::getDrawingUrl)
+                .toList()
+                : List.of();
+
         return new MemberProjectQueryResponse(
                 project.getId(),
                 project.getModifiedAt(),
                 ProjectRegisterRequest.from(project),
-                project.getDrawingFiles().stream()
-                        .map(ProjectDrawingFile::getDrawingUrl)
-                        .toList()
+                drawingUrls
         );
     }
 }

--- a/src/main/java/hanieum/conik/adapter/project/dto/response/ProjectDetailResponse.java
+++ b/src/main/java/hanieum/conik/adapter/project/dto/response/ProjectDetailResponse.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record MemberProjectQueryResponse(
+public record ProjectDetailResponse(
         @Schema(description = "프로젝트 PK", example = "1")
         Long projectId,
 
@@ -21,14 +21,14 @@ public record MemberProjectQueryResponse(
         @Schema(description = "프로젝트 도면 파일 목록")
         List<String> drawingUrls
 ) {
-    public static MemberProjectQueryResponse from(Project project){
+    public static ProjectDetailResponse from(Project project){
         List<String> drawingUrls = (project.getDrawingFiles() != null)
                 ? project.getDrawingFiles().stream()
                 .map(ProjectDrawingFile::getDrawingUrl)
                 .toList()
                 : List.of();
 
-        return new MemberProjectQueryResponse(
+        return new ProjectDetailResponse(
                 project.getId(),
                 project.getModifiedAt(),
                 ProjectRegisterRequest.from(project),

--- a/src/main/java/hanieum/conik/adapter/project/dto/response/ProjectWithProposalsResponse.java
+++ b/src/main/java/hanieum/conik/adapter/project/dto/response/ProjectWithProposalsResponse.java
@@ -1,0 +1,11 @@
+package hanieum.conik.adapter.project.dto.response;
+
+import hanieum.conik.adapter.proposal.dto.response.ProposalThumbnailResponse;
+
+import java.util.List;
+
+public record ProjectWithProposalsResponse (
+    ProjectDetailResponse projectDetailResponse,
+
+    List<ProposalThumbnailResponse> proposalThumbnails
+){ }

--- a/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
+++ b/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
@@ -74,17 +74,14 @@ public class ProjectController {
     public ApiResponse<Page<MemberProjectQueryResponse>> getMemberProjects(@RequestParam(value = "status", required = false) SubmitStatus submitStatus,
                                                                            @RequestParam(value = "memberId", required = false) Long memberId,
                                                                            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<Project> projects = projectFinder.getMemberProjects(memberId, submitStatus, pageable);
 
-        return ApiResponse.success(projects.map(MemberProjectQueryResponse::from));
+        return ApiResponse.success(projectFinder.getMemberProjects(memberId, submitStatus, pageable));
     }
 
     @Operation(summary = "특정 프로젝트(공고) 조회 API", description = "프로젝트 ID로 특정 프로젝트를 조회합니다.")
     @GetMapping("/detail/{projectId}")
-    @AuthorizeUser(sourceType = AuthSourceType.REQUEST_PARAM, paramName = "memberId")
-    public ApiResponse<MemberProjectQueryResponse> getProject(@PathVariable("projectId") Long projectId,
-                                                              @RequestParam("memberId") Long memberId) {
-        Project project = projectFinder.getProjectDetail(projectId, memberId);
+    public ApiResponse<MemberProjectQueryResponse> getProject(@PathVariable("projectId") Long projectId) {
+        Project project = projectFinder.getProjectDetail(projectId);
 
         return ApiResponse.success(MemberProjectQueryResponse.from(project));
     }

--- a/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
+++ b/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
@@ -3,7 +3,8 @@ package hanieum.conik.adapter.project.webapi;
 import hanieum.conik.adapter.project.dto.request.BidStatusUpdateRequest;
 import hanieum.conik.adapter.project.dto.request.ProjectDrawingUploadRequest;
 import hanieum.conik.adapter.project.dto.request.ProjectRegisterRequest;
-import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
+import hanieum.conik.adapter.project.dto.response.ProjectDetailResponse;
+import hanieum.conik.adapter.project.dto.response.ProjectWithProposalsResponse;
 import hanieum.conik.application.project.provided.ProjectDrawingSaver;
 import hanieum.conik.application.project.provided.ProjectFinder;
 import hanieum.conik.application.project.provided.ProjectSaver;
@@ -43,56 +44,55 @@ public class ProjectController {
     @Operation(summary = "초기 프로젝트(공고) 생성 API", description = "초기에 프로젝트(공고) 페이지를 생성합니다.")
     @PostMapping("{memberId}/init")
     @AuthorizeUser(sourceType = AuthSourceType.PATH_VARIABLE, paramName = "memberId")
-    public ApiResponse<MemberProjectQueryResponse> initProject(@PathVariable("memberId") Long memberId) {
+    public ApiResponse<ProjectDetailResponse> initProject(@PathVariable("memberId") Long memberId) {
         Project project = projectSaver.initiate(memberId);
 
-        return ApiResponse.success(MemberProjectQueryResponse.from(project));
+        return ApiResponse.success(ProjectDetailResponse.from(project));
     }
 
     @Operation(summary = "프로젝트(공고) 수정 및 임시저장 API", description = "임시 저장 시, 발급된 프로젝트(공고)에 대해 정보를 수정합니다.")
     @PostMapping("{projectId}/draft")
     @AuthorizeUser(sourceType = AuthSourceType.REQUEST_BODY, fieldName = "memberId")
-    public ApiResponse<MemberProjectQueryResponse> saveProjectTemp(@PathVariable("projectId") Long projectId,
-                                                               @RequestBody ProjectRegisterRequest projectRegisterRequest) {
+    public ApiResponse<ProjectDetailResponse> saveProjectTemp(@PathVariable("projectId") Long projectId,
+                                                              @RequestBody ProjectRegisterRequest projectRegisterRequest) {
         Project project = projectSaver.saveProjectDraft(projectId, projectRegisterRequest);
 
-        return ApiResponse.success(MemberProjectQueryResponse.from(project));
+        return ApiResponse.success(ProjectDetailResponse.from(project));
     }
 
     @Operation(summary = "프로젝트(공고) 수정 및 저장 API", description = "작성 완료 된 프로젝트(공고)를 최종 저장합니다.")
     @PostMapping("{projectId}/final")
     @AuthorizeUser(sourceType = AuthSourceType.REQUEST_BODY, fieldName = "memberId")
-    public ApiResponse<MemberProjectQueryResponse> saveProjectFinal(@PathVariable("projectId") Long projectId,
-                                                                @RequestBody @Valid ProjectRegisterRequest projectRegisterRequest) {
+    public ApiResponse<ProjectDetailResponse> saveProjectFinal(@PathVariable("projectId") Long projectId,
+                                                               @RequestBody @Valid ProjectRegisterRequest projectRegisterRequest) {
         Project project = projectSaver.saveProjectFinal(projectId, projectRegisterRequest);
 
-        return ApiResponse.success(MemberProjectQueryResponse.from(project));
+        return ApiResponse.success(ProjectDetailResponse.from(project));
     }
 
     @Operation(summary = "사용자 프로젝트(공고) 조회 API", description = "사용자의 프로젝트(공고) 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<Page<MemberProjectQueryResponse>> getMemberProjects(@RequestParam(value = "status", required = false) SubmitStatus submitStatus,
-                                                                           @RequestParam(value = "memberId", required = false) Long memberId,
-                                                                           @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public ApiResponse<Page<ProjectDetailResponse>> getMemberProjects(@RequestParam(value = "status", required = false) SubmitStatus submitStatus,
+                                                                      @RequestParam(value = "memberId", required = false) Long memberId,
+                                                                      @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return ApiResponse.success(projectFinder.getMemberProjects(memberId, submitStatus, pageable));
     }
 
     @Operation(summary = "특정 프로젝트(공고) 조회 API", description = "프로젝트 ID로 특정 프로젝트를 조회합니다.")
     @GetMapping("/{projectId}/detail")
-    public ApiResponse<MemberProjectQueryResponse> getProject(@PathVariable("projectId") Long projectId) {
-        Project project = projectFinder.getProjectDetail(projectId);
+    public ApiResponse<ProjectWithProposalsResponse> getProject(@PathVariable("projectId") Long projectId) {
 
-        return ApiResponse.success(MemberProjectQueryResponse.from(project));
+        return ApiResponse.success(projectFinder.getProjectDetailWithProposals(projectId));
     }
 
     @Operation(summary = "프로젝트(공고) 입찰 상태 변경 API", description = "프로젝트(공고)의 입찰 상태를 변경합니다.")
     @PatchMapping("/{projectId}/status")
     @AuthorizeUser(sourceType = AuthSourceType.REQUEST_BODY, fieldName = "memberId")
-    public ApiResponse<MemberProjectQueryResponse> changeProjectStatus(@PathVariable("projectId") Long projectId,
-                                                                       @RequestBody @Valid  BidStatusUpdateRequest bidStatusUpdateRequest) {
+    public ApiResponse<ProjectDetailResponse> changeProjectStatus(@PathVariable("projectId") Long projectId,
+                                                                  @RequestBody @Valid  BidStatusUpdateRequest bidStatusUpdateRequest) {
         Project project = projectSaver.updateProjectBidStatus(projectId, bidStatusUpdateRequest);
 
-        return ApiResponse.success(MemberProjectQueryResponse.from(project));
+        return ApiResponse.success(ProjectDetailResponse.from(project));
     }
 }

--- a/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
+++ b/src/main/java/hanieum/conik/adapter/project/webapi/ProjectController.java
@@ -79,7 +79,7 @@ public class ProjectController {
     }
 
     @Operation(summary = "특정 프로젝트(공고) 조회 API", description = "프로젝트 ID로 특정 프로젝트를 조회합니다.")
-    @GetMapping("/detail/{projectId}")
+    @GetMapping("/{projectId}/detail")
     public ApiResponse<MemberProjectQueryResponse> getProject(@PathVariable("projectId") Long projectId) {
         Project project = projectFinder.getProjectDetail(projectId);
 

--- a/src/main/java/hanieum/conik/adapter/proposal/dto/request/ProposalRegisterRequest.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/dto/request/ProposalRegisterRequest.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record ProposalRegisterRequest(
@@ -29,6 +30,8 @@ public record ProposalRegisterRequest(
         Long secondPrice,
 
         String proposalNote,
+
+        LocalDate operateUntil,
 
         @NotEmpty(message = "견적 항목은 최소 1개 이상이어야 합니다")
         @Valid
@@ -57,6 +60,7 @@ public record ProposalRegisterRequest(
                 proposal.getFirstPrice(),
                 proposal.getSecondPrice(),
                 proposal.getProposalNote(),
+                proposal.getOperateUntil(),
                 items,
                 proposal.getProposalBidStatus(),
                 proposal.getSubmitStatus()

--- a/src/main/java/hanieum/conik/adapter/proposal/dto/request/ProposalRegisterRequest.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/dto/request/ProposalRegisterRequest.java
@@ -43,6 +43,13 @@ public record ProposalRegisterRequest(
         SubmitStatus submitStatus
 ) {
     public static ProposalRegisterRequest from(Proposal proposal) {
+        List<ProposalItemRequest> items = proposal.getItems().stream()
+                .map(ProposalItemRequest::from)
+                .toList();
+        return from(proposal, items);
+    }
+
+    public static ProposalRegisterRequest from(Proposal proposal, List<ProposalItemRequest> items) {
         return new ProposalRegisterRequest(
                 proposal.getProjectId(),
                 proposal.getCompanyId(),
@@ -50,9 +57,7 @@ public record ProposalRegisterRequest(
                 proposal.getFirstPrice(),
                 proposal.getSecondPrice(),
                 proposal.getProposalNote(),
-                proposal.getItems().stream()
-                        .map(ProposalItemRequest::from)
-                        .toList(),
+                items,
                 proposal.getProposalBidStatus(),
                 proposal.getSubmitStatus()
         );

--- a/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalResponse.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalResponse.java
@@ -25,5 +25,15 @@ public record ProposalResponse(
                 ProposalRegisterRequest.from(proposal)
         );
     }
+
+    public static ProposalResponse from(Proposal proposal, ProposalRegisterRequest registerRequest) {
+        Objects.requireNonNull(proposal, "proposal must not be null");
+        Objects.requireNonNull(registerRequest, "proposalRegisterRequest must not be null");
+        return new ProposalResponse(
+                proposal.getId(),
+                proposal.getModifiedAt(),
+                registerRequest
+        );
+    }
 }
 

--- a/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalThumbnailResponse.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/dto/response/ProposalThumbnailResponse.java
@@ -1,0 +1,27 @@
+package hanieum.conik.adapter.proposal.dto.response;
+
+import hanieum.conik.adapter.company.webapi.response.CompanyThumbnailResponse;
+import hanieum.conik.domain.company.Company;
+import hanieum.conik.domain.proposal.domain.entity.Proposal;
+
+import java.time.LocalDate;
+
+public record ProposalThumbnailResponse(
+
+        Long proposalId,
+
+        CompanyThumbnailResponse companyThumbnailResponse,
+
+        Long totalPrice,
+
+        LocalDate operateUntil
+) {
+    public static ProposalThumbnailResponse from(Proposal proposal, Company company) {
+        return new ProposalThumbnailResponse(
+                proposal.getId(),
+                CompanyThumbnailResponse.from(company),
+                proposal.getTotalPrice(),
+                proposal.getOperateUntil()
+        );
+    }
+}

--- a/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
+++ b/src/main/java/hanieum/conik/adapter/proposal/webapi/ProposalController.java
@@ -83,7 +83,7 @@ public class ProposalController {
     @Operation(summary = "기업 견적서(입찰) 단일 조회 API", description = "특정 기업 견적서(입찰)를 조회합니다.")
     @GetMapping("/{proposalId}/detail")
     public ApiResponse<ProposalDetailResponse> getProposal(@PathVariable("proposalId") Long proposalId) {
-        Proposal proposal = proposalFinder.getProposalDetail(proposalId);
+        Proposal proposal = proposalFinder.findProposal(proposalId);
 
         return ApiResponse.success(ProposalDetailResponse.from(proposal) ) ;
     }

--- a/src/main/java/hanieum/conik/application/company/CompanyService.java
+++ b/src/main/java/hanieum/conik/application/company/CompanyService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.Collection;
 import java.util.List;
 
 @Slf4j
@@ -60,5 +61,10 @@ public class CompanyService implements CompanyFinder, CompanyRegister {
         log.info("기업 등록 성공: company id = {}", company.getId());
 
         return company.getId();
+    }
+
+    @Override
+    public List<Company> findCompaniesWithDetail(Collection<Long> ids) {
+        return companyRepository.findAllWithDetailByIdIn(ids);
     }
 }

--- a/src/main/java/hanieum/conik/application/company/CompanyService.java
+++ b/src/main/java/hanieum/conik/application/company/CompanyService.java
@@ -46,6 +46,12 @@ public class CompanyService implements CompanyFinder, CompanyRegister {
     }
 
     @Override
+    public Company findCompanyWithDetail(Long companyId) {
+        return companyRepository.findByIdWithDetail(companyId)
+                .orElseThrow(() -> new CompanyException(CompanyErrorType.COMPANY_NOT_FOUND));
+    }
+
+    @Override
     public Long register(CompanyRegisterRequest request) {
 
         Company company = Company.register(request);

--- a/src/main/java/hanieum/conik/application/company/provided/CompanyFinder.java
+++ b/src/main/java/hanieum/conik/application/company/provided/CompanyFinder.java
@@ -12,5 +12,7 @@ public interface CompanyFinder {
 
     Company findCompany(Long companyId);
 
+    Company findCompanyWithDetail(Long companyId);
+
     Company findCompanyWithAddresses(Long companyId);
 }

--- a/src/main/java/hanieum/conik/application/company/provided/CompanyFinder.java
+++ b/src/main/java/hanieum/conik/application/company/provided/CompanyFinder.java
@@ -2,6 +2,7 @@ package hanieum.conik.application.company.provided;
 
 import hanieum.conik.domain.company.Company;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -15,4 +16,6 @@ public interface CompanyFinder {
     Company findCompanyWithDetail(Long companyId);
 
     Company findCompanyWithAddresses(Long companyId);
+
+    List<Company> findCompaniesWithDetail(Collection<Long> ids);
 }

--- a/src/main/java/hanieum/conik/application/company/required/CompanyRepository.java
+++ b/src/main/java/hanieum/conik/application/company/required/CompanyRepository.java
@@ -8,6 +8,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
+
     @Query("SELECT c FROM Company c LEFT JOIN FETCH c.addresses WHERE c.id = :id")
     Optional<Company> findByIdWithAddresses(@Param("id") Long id);
+
+    @Query("SELECT c FROM Company c LEFT JOIN FETCH c.companyDetail WHERE c.id = :id")
+    Optional<Company> findByIdWithDetail(@Param("id") Long id);
 }

--- a/src/main/java/hanieum/conik/application/company/required/CompanyRepository.java
+++ b/src/main/java/hanieum/conik/application/company/required/CompanyRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
@@ -14,4 +16,7 @@ public interface CompanyRepository extends JpaRepository<Company, Long> {
 
     @Query("SELECT c FROM Company c LEFT JOIN FETCH c.companyDetail WHERE c.id = :id")
     Optional<Company> findByIdWithDetail(@Param("id") Long id);
+
+    @Query("SELECT c from Company c LEFT JOIN FETCH c.companyDetail where c.id in :ids")
+    List<Company> findAllWithDetailByIdIn(@Param("ids") Collection<Long> ids);
 }

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -2,12 +2,10 @@ package hanieum.conik.application.project;
 
 import hanieum.conik.adapter.project.dto.request.BidStatusUpdateRequest;
 import hanieum.conik.adapter.project.dto.request.ProjectRegisterRequest;
-import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
 import hanieum.conik.application.project.provided.ProjectFinder;
 import hanieum.conik.application.project.provided.ProjectSaver;
 import hanieum.conik.application.project.required.ProjectRepository;
 import hanieum.conik.domain.project.entity.Project;
-import hanieum.conik.domain.project.entity.ProjectDrawingFile;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.domain.project.exception.ProjectErrorType;
 import hanieum.conik.domain.project.exception.ProjectException;
@@ -53,7 +51,7 @@ public class ProjectModifyService implements ProjectSaver {
     @Override
     public Project updateProjectBidStatus(Long projectId, BidStatusUpdateRequest bidStatusUpdateRequest) {
         try {
-            Project project = projectFinder.getProjectDetail(projectId);
+            Project project = projectFinder.findProject(projectId);
             project.updateBidStatusAndPublicUntil(bidStatusUpdateRequest);
 
             return projectRepository.save(project);
@@ -78,6 +76,4 @@ public class ProjectModifyService implements ProjectSaver {
             throw new ProjectException(ProjectErrorType.PROJECT_SAVE_ERROR);
         }
     }
-
-
 }

--- a/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectModifyService.java
@@ -53,7 +53,7 @@ public class ProjectModifyService implements ProjectSaver {
     @Override
     public Project updateProjectBidStatus(Long projectId, BidStatusUpdateRequest bidStatusUpdateRequest) {
         try {
-            Project project = projectFinder.findProject(projectId);
+            Project project = projectFinder.getProjectDetail(projectId);
             project.updateBidStatusAndPublicUntil(bidStatusUpdateRequest);
 
             return projectRepository.save(project);

--- a/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
@@ -1,6 +1,5 @@
 package hanieum.conik.application.project;
 
-import hanieum.conik.adapter.project.dto.request.ProjectRegisterRequest;
 import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
 import hanieum.conik.application.project.provided.ProjectFinder;
 import hanieum.conik.application.project.required.ProjectRepository;
@@ -30,13 +29,16 @@ public class ProjectQueryService implements ProjectFinder {
     }
 
     @Override
-    public Page<Project> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable) {
+    public Page<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable) {
+        Page<Project> projects;
 
         if (memberId != null) {
-            return findProjectsWithStatus(submitStatus, memberId, pageable);
+            projects = findProjectsWithStatus(submitStatus, memberId, pageable);
         } else {
-            return findAllProjectsWithStatus(submitStatus, pageable);
+            projects = findAllProjectsWithStatus(submitStatus, pageable);
         }
+
+        return projects.map(MemberProjectQueryResponse::from);
     }
 
     private Page<Project> findProjectsWithStatus(SubmitStatus submitStatus, Long memberId, Pageable pageable) {
@@ -61,7 +63,8 @@ public class ProjectQueryService implements ProjectFinder {
     }
 
     @Override
-    public Project getProjectDetail(Long projectId, Long memberId){
-        return findProject(projectId);
+    public Project getProjectDetail(Long projectId){
+        return projectRepository.findByIdWithDrawingFiles(projectId)
+                .orElseThrow(() -> new ProjectException(ProjectErrorType.PROJECT_NOT_FOUND));
     }
 }

--- a/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
@@ -22,6 +22,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -80,9 +84,17 @@ public class ProjectQueryService implements ProjectFinder {
         // 2. ProposalFinder를 통해 제안서들 조회
         List<Proposal> proposals = proposalFinder.findSubmittedProposalsByProjectId(projectId);
 
-        // 3. 제안서별 회사 정보 조회 및 DTO 조합
+        // 3. 회사들 일괄 로딩 후 매핑
+        Set<Long> companyIds = proposals.stream()
+                .map(Proposal::getCompanyId)
+                .collect(Collectors.toSet());
+
+        Map<Long, Company> companyMap = companyFinder.findCompaniesWithDetail(companyIds).stream()
+                .collect(Collectors.toMap(Company::getId, Function.identity()));
+
+        // 4) DTO 조합 (단건 조회 제거)
         List<ProposalThumbnailResponse> proposalThumbnails = proposals.stream()
-                .map(this::createProposalThumbnailResponse)
+                .map(p -> ProposalThumbnailResponse.from(p, companyMap.get(p.getCompanyId())))
                 .toList();
 
         // 4. 최종 응답 조합

--- a/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
+++ b/src/main/java/hanieum/conik/application/project/ProjectQueryService.java
@@ -1,12 +1,19 @@
 package hanieum.conik.application.project;
 
-import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
+import hanieum.conik.adapter.company.webapi.response.CompanyThumbnailResponse;
+import hanieum.conik.adapter.project.dto.response.ProjectDetailResponse;
+import hanieum.conik.adapter.project.dto.response.ProjectWithProposalsResponse;
+import hanieum.conik.adapter.proposal.dto.response.ProposalThumbnailResponse;
+import hanieum.conik.application.company.provided.CompanyFinder;
 import hanieum.conik.application.project.provided.ProjectFinder;
 import hanieum.conik.application.project.required.ProjectRepository;
+import hanieum.conik.application.proposal.provided.ProposalFinder;
+import hanieum.conik.domain.company.Company;
 import hanieum.conik.domain.project.entity.Project;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import hanieum.conik.domain.project.exception.ProjectErrorType;
 import hanieum.conik.domain.project.exception.ProjectException;
+import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,6 +28,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class ProjectQueryService implements ProjectFinder {
     private final ProjectRepository projectRepository;
+    private final ProposalFinder proposalFinder;
+    private final CompanyFinder companyFinder;
 
     @Override
     public Project findProject(Long projectId) {
@@ -29,7 +38,7 @@ public class ProjectQueryService implements ProjectFinder {
     }
 
     @Override
-    public Page<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable) {
+    public Page<ProjectDetailResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable) {
         Page<Project> projects;
 
         if (memberId != null) {
@@ -38,7 +47,7 @@ public class ProjectQueryService implements ProjectFinder {
             projects = findAllProjectsWithStatus(submitStatus, pageable);
         }
 
-        return projects.map(MemberProjectQueryResponse::from);
+        return projects.map(ProjectDetailResponse::from);
     }
 
     private Page<Project> findProjectsWithStatus(SubmitStatus submitStatus, Long memberId, Pageable pageable) {
@@ -63,8 +72,29 @@ public class ProjectQueryService implements ProjectFinder {
     }
 
     @Override
-    public Project getProjectDetail(Long projectId){
-        return projectRepository.findByIdWithDrawingFiles(projectId)
+    public ProjectWithProposalsResponse getProjectDetailWithProposals(Long projectId) {
+        // 1. 프로젝트 조회
+        Project project = projectRepository.findByIdWithDrawingFiles(projectId)
                 .orElseThrow(() -> new ProjectException(ProjectErrorType.PROJECT_NOT_FOUND));
+
+        // 2. ProposalFinder를 통해 제안서들 조회
+        List<Proposal> proposals = proposalFinder.findSubmittedProposalsByProjectId(projectId);
+
+        // 3. 제안서별 회사 정보 조회 및 DTO 조합
+        List<ProposalThumbnailResponse> proposalThumbnails = proposals.stream()
+                .map(this::createProposalThumbnailResponse)
+                .toList();
+
+        // 4. 최종 응답 조합
+        return new ProjectWithProposalsResponse(
+                ProjectDetailResponse.from(project),
+                proposalThumbnails
+        );
+    }
+
+    private ProposalThumbnailResponse createProposalThumbnailResponse(Proposal proposal) {
+        Company companyWithDetail = companyFinder.findCompanyWithDetail(proposal.getCompanyId());
+
+        return ProposalThumbnailResponse.from(proposal, companyWithDetail);
     }
 }

--- a/src/main/java/hanieum/conik/application/project/provided/ProjectFinder.java
+++ b/src/main/java/hanieum/conik/application/project/provided/ProjectFinder.java
@@ -11,7 +11,8 @@ public interface ProjectFinder {
 
     Project validateProjectOpenStatus(Long projectId);
 
-    Project getProjectDetail(Long projectId, Long memberId);
+    Project getProjectDetail(Long projectId);
 
-    Page<Project> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable);
+    Page<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable);
+
 }

--- a/src/main/java/hanieum/conik/application/project/provided/ProjectFinder.java
+++ b/src/main/java/hanieum/conik/application/project/provided/ProjectFinder.java
@@ -1,6 +1,7 @@
 package hanieum.conik.application.project.provided;
 
-import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
+import hanieum.conik.adapter.project.dto.response.ProjectDetailResponse;
+import hanieum.conik.adapter.project.dto.response.ProjectWithProposalsResponse;
 import hanieum.conik.domain.project.entity.Project;
 import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import org.springframework.data.domain.Page;
@@ -11,8 +12,8 @@ public interface ProjectFinder {
 
     Project validateProjectOpenStatus(Long projectId);
 
-    Project getProjectDetail(Long projectId);
+    ProjectWithProposalsResponse getProjectDetailWithProposals(Long projectId);
 
-    Page<MemberProjectQueryResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable);
+    Page<ProjectDetailResponse> getMemberProjects(Long memberId, SubmitStatus submitStatus, Pageable pageable);
 
 }

--- a/src/main/java/hanieum/conik/application/project/provided/ProjectSaver.java
+++ b/src/main/java/hanieum/conik/application/project/provided/ProjectSaver.java
@@ -2,8 +2,6 @@ package hanieum.conik.application.project.provided;
 
 import hanieum.conik.adapter.project.dto.request.BidStatusUpdateRequest;
 import hanieum.conik.adapter.project.dto.request.ProjectRegisterRequest;
-import hanieum.conik.adapter.project.dto.response.MemberProjectQueryResponse;
-import hanieum.conik.domain.member.Member;
 import hanieum.conik.domain.project.entity.Project;
 
 public interface ProjectSaver {

--- a/src/main/java/hanieum/conik/application/project/required/ProjectRepository.java
+++ b/src/main/java/hanieum/conik/application/project/required/ProjectRepository.java
@@ -5,11 +5,22 @@ import hanieum.conik.domain.project.enumerate.SubmitStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     List<Project> findByMemberId(Long memberId);
+
+    @Query("""
+        select distinct p
+        from Project p
+        left join fetch p.drawingFiles df
+        where p.id = :id
+    """)
+    Optional<Project> findByIdWithDrawingFiles(@Param("id") Long id);
 
     Page<Project> findByMemberIdAndSubmitStatus(Long memberId, SubmitStatus submitStatus, Pageable pageable);
 

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -72,7 +72,6 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
         try {
             Proposal proposal = proposalFinder.getProposalDetail(proposalId);
             proposal.update(request);
-
             Consumer<Proposal> handler = statusHandlers.get(request.submitStatus());
             handler.accept(proposal);
 

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -95,7 +95,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
     @Override
     public Proposal updateToDealRequested(Long proposalId) {
         Proposal proposal = proposalFinder.findProposal(proposalId);
-        if (!proposal.getProposalBidStatus().equals(ProposalBidStatus.PRE_BID)) {
+        if (!ProposalBidStatus.PRE_BID.equals(proposal.getProposalBidStatus())) {
             throw new ProposalException(ProposalErrorType.PROPOSAL_DEAL_REQUEST_ERROR);
         }
 

--- a/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalModifyService.java
@@ -70,7 +70,7 @@ public class ProposalModifyService implements ProposalSaver, ProposalDrawingSave
 
     private Proposal getSavedProposal(Long proposalId, ProposalRegisterRequest request) {
         try {
-            Proposal proposal = proposalFinder.getProposalDetail(proposalId);
+            Proposal proposal = proposalFinder.findProposal(proposalId);
             proposal.update(request);
             Consumer<Proposal> handler = statusHandlers.get(request.submitStatus());
             handler.accept(proposal);

--- a/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
@@ -51,12 +51,6 @@ public class ProposalQueryService implements ProposalFinder {
     }
 
     @Override
-    public Proposal getProposalDetail(Long proposalId){
-        return proposalRepository.findById(proposalId)
-                .orElseThrow(() -> new ProposalException(ProposalErrorType.PROPOSAL_NOT_FOUND));
-    }
-
-    @Override
     public List<Proposal> findSubmittedProposalsByProjectId(Long projectId) {
         return proposalRepository.findByProjectIdAndSubmitStatus(projectId, SubmitStatus.SUBMIT);
     }

--- a/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
+++ b/src/main/java/hanieum/conik/application/proposal/ProposalQueryService.java
@@ -52,7 +52,12 @@ public class ProposalQueryService implements ProposalFinder {
 
     @Override
     public Proposal getProposalDetail(Long proposalId){
-        return proposalRepository.findDetailById(proposalId)
+        return proposalRepository.findById(proposalId)
                 .orElseThrow(() -> new ProposalException(ProposalErrorType.PROPOSAL_NOT_FOUND));
+    }
+
+    @Override
+    public List<Proposal> findSubmittedProposalsByProjectId(Long projectId) {
+        return proposalRepository.findByProjectIdAndSubmitStatus(projectId, SubmitStatus.SUBMIT);
     }
 }

--- a/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
+++ b/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
@@ -10,8 +10,6 @@ import java.util.List;
 public interface ProposalFinder {
     Proposal findProposal(Long proposalId);
 
-    Proposal getProposalDetail(Long proposalId);
-
     List<Proposal> findSubmittedProposalsByProjectId(Long projectId);
 
     Page<Proposal> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus, Pageable pageable);

--- a/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
+++ b/src/main/java/hanieum/conik/application/proposal/provided/ProposalFinder.java
@@ -5,10 +5,14 @@ import hanieum.conik.domain.proposal.domain.entity.Proposal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ProposalFinder {
     Proposal findProposal(Long proposalId);
 
     Proposal getProposalDetail(Long proposalId);
+
+    List<Proposal> findSubmittedProposalsByProjectId(Long projectId);
 
     Page<Proposal> getCompanyProposals(Long memberId, Long projectId, SubmitStatus submitStatus, Pageable pageable);
 }

--- a/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
+++ b/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
@@ -18,6 +18,8 @@ public interface ProposalRepository extends JpaRepository<Proposal, Long> {
             "where p.id = :id")
     Optional<Proposal> findDetailById(@Param("id") Long id);
 
+    List<Proposal> findByProjectIdAndSubmitStatus(Long projectId, SubmitStatus submitStatus);
+
     Page<Proposal> findByCompanyIdAndSubmitStatusIn(Long companyId, List<SubmitStatus> submitStatuses, Pageable pageable);
 
     Page<Proposal> findByCompanyIdAndSubmitStatus(Long companyId, SubmitStatus submitStatus, Pageable pageable);

--- a/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
+++ b/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
-    @Query("select p from Proposal p " +
+    @Query("select distinct p from Proposal p " +
             "left join fetch p.items " +
             "left join fetch p.drawingFiles " +
             "where p.id = :id")

--- a/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
+++ b/src/main/java/hanieum/conik/application/proposal/required/ProposalRepository.java
@@ -18,6 +18,7 @@ public interface ProposalRepository extends JpaRepository<Proposal, Long> {
             "where p.id = :id")
     Optional<Proposal> findDetailById(@Param("id") Long id);
 
+
     List<Proposal> findByProjectIdAndSubmitStatus(Long projectId, SubmitStatus submitStatus);
 
     Page<Proposal> findByCompanyIdAndSubmitStatusIn(Long companyId, List<SubmitStatus> submitStatuses, Pageable pageable);

--- a/src/main/java/hanieum/conik/domain/company/Company.java
+++ b/src/main/java/hanieum/conik/domain/company/Company.java
@@ -51,11 +51,14 @@ public class Company extends BaseEntity {
     private String bankbookCopy;  // 통장사본
 
     @Column(nullable = false, length = 2048)
-    private String profileUrl; // 프로필 사진 URL
+    private String profileUrl; // 회사 소개서
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private CompanyStatus status;
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private CompanyDetail companyDetail;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "company_id", nullable = false)

--- a/src/main/java/hanieum/conik/domain/company/CompanyDetail.java
+++ b/src/main/java/hanieum/conik/domain/company/CompanyDetail.java
@@ -1,0 +1,18 @@
+package hanieum.conik.domain.company;
+
+import hanieum.conik.global.domain.AbstractEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "company_detail")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CompanyDetail extends AbstractEntity {
+
+    @Column(nullable = false, length = 2048)
+    private String logoUrl; // 회사 로고 URL
+}
+

--- a/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
+++ b/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +33,8 @@ public class Proposal extends AbstractEntity {
     private Long secondPrice;
 
     private String proposalNote;
+
+    private LocalDate operateUntil;
 
     private SubmitStatus submitStatus = SubmitStatus.INITIALIZE;
 

--- a/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
+++ b/src/main/java/hanieum/conik/domain/proposal/domain/entity/Proposal.java
@@ -47,7 +47,7 @@ public class Proposal extends AbstractEntity {
     private List<ProposalDrawingFile> drawingFiles = new ArrayList<>();
 
     public static Proposal create(Long projectId, Long companyId, Long totalPrice,
-                                  Long firstPrice, Long secondPrice, String proposalNote) {
+                                  Long firstPrice, Long secondPrice, String proposalNote, LocalDate operateUntil) {
         Proposal proposal = new Proposal();
         proposal.projectId = projectId;
         proposal.companyId = companyId;
@@ -55,6 +55,7 @@ public class Proposal extends AbstractEntity {
         proposal.firstPrice = firstPrice;
         proposal.secondPrice = secondPrice;
         proposal.proposalNote = proposalNote;
+        proposal.operateUntil = operateUntil;
         return proposal;
     }
 
@@ -90,7 +91,7 @@ public class Proposal extends AbstractEntity {
         this.firstPrice = proposalRegisterRequest.firstPrice();
         this.secondPrice = proposalRegisterRequest.secondPrice();
         this.proposalNote = proposalRegisterRequest.proposalNote();
-
+        this.operateUntil = proposalRegisterRequest.operateUntil();
         this.items.clear();
 
         for (ProposalItemRequest proposalItemRequest : proposalRegisterRequest.items()) {

--- a/src/main/resources/META-INF/Proposal-orm.xml
+++ b/src/main/resources/META-INF/Proposal-orm.xml
@@ -26,6 +26,9 @@
             <basic name="proposalNote">
                 <column name="proposal_note"/>
             </basic>
+            <basic name="operateUntil">
+                <column name="operate_until"/>
+            </basic>
             <basic name="submitStatus">
                 <column name="submit_status"/>
                 <enumerated>STRING</enumerated>

--- a/src/test/java/hanieum/conik/proposal/domain/entity/ProposalOrphanRemovalTest.java
+++ b/src/test/java/hanieum/conik/proposal/domain/entity/ProposalOrphanRemovalTest.java
@@ -28,7 +28,9 @@ class ProposalOrphanRemovalTest {
                 1000000L,          // totalPrice
                 500000L,           // firstPrice
                 500000L,           // secondPrice
-                "테스트 노트"       // proposalNote
+                "테스트 노트",       // proposalNote
+                null
+                                // operateUntil (null로 설정)
         );
 
         // ProposalItem 생성 및 연결
@@ -80,7 +82,7 @@ class ProposalOrphanRemovalTest {
         // given
         Proposal proposal = Proposal.create(
                 1L, 1L, 1000000L, 500000L,
-                500000L,  "테스트 노트"
+                500000L,  "테스트 노트", null
         );
 
         ProposalItem item = ProposalItem.create(


### PR DESCRIPTION
## 📝 작업 내용
> 프로젝트 상세 조회 시 제안서 목록을 함께 반환하는 API 개발 및 Proposal 수정 기능 디버깅

## 🧑‍💻 변경 사항

### 1. **ProjectQueryService - 프로젝트 상세 조회 API 개선**
- 프로젝트 상세 정보와 제안서 목록을 함께 조회하는 메서드 추가
- 제출된 제안서 목록 조회 및 변환 로직 구현
- 통합 응답 객체 반환 구조 개발

### 2. **ProposalThumbnailResponse - 정적 팩토리 메서드 추가**
- Proposal과 Company 엔티티로부터 썸네일 응답 객체를 생성하는 정적 팩토리 메서드 구현
- 객체 생성 로직 캡슐화로 코드 가독성 향상

### 3. **ProposalRepository 쿼리 최적화**
- 제안서 상세 조회 시 연관된 items와 drawingFiles를 함께 조회하는 쿼리 작성
- N+1 문제 해결을 위한 fetch join 적용

### 4. **Proposal 수정 기능 디버깅**
- getSavedProposal 메서드에서 proposalFinder.getProposalDetail 호출 시 발생하는 에러 분석
- Multiple Bag Fetch Exception 가능성 식별 및 원인 파악

## 💬 리뷰 요구사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 프로젝트 상세에서 제안서 썸네일 목록 제공(회사명·로고, 총 금액, 운영 종료일 표시).
  - 회사 썸네일 정보 제공(회사명·로고).
  - 제안서에 운영 종료일(operateUntil) 필드 추가로 마감일 노출 가능.
  - 내 프로젝트 목록/상세가 통일된 상세 형식으로 응답되어 가독성 향상.
  - 프로젝트 상세 조회 경로 변경: /{projectId}/detail (더 이상 memberId 필요 없음).

- **버그 수정**
  - 제안서 상태 검사 시 null 안전성 개선으로 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->