### PR TITLE
[FIX]: url 저장 크기를 변경한다

### DIFF
--- a/src/main/resources/META-INF/ProjectDrawingFile-orm.xml
+++ b/src/main/resources/META-INF/ProjectDrawingFile-orm.xml
@@ -9,7 +9,7 @@
         <table name="project_drawing_file"/>
         <attributes>
             <basic name="drawingUrl">
-                <column name="drawing_url" nullable="false"/>
+                <column name="drawing_url" nullable="false" length="2500"/>
             </basic>
             <basic name="uploadStatus">
                 <column name="upload_status" nullable="false"/>

--- a/src/main/resources/META-INF/ProposalDrawingFile-orm.xml
+++ b/src/main/resources/META-INF/ProposalDrawingFile-orm.xml
@@ -9,7 +9,7 @@
         <table name="proposal_drawing_file"/>
         <attributes>
             <basic name="drawingUrl">
-                <column nullable="false"/>
+                <column nullable="false" length="2500"/>
             </basic>
             <basic name="uploadStatus">
                 <column name="upload_status" nullable="false"/>


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 프로젝트 도면 파일의 도면 URL 최대 길이를 2,500자로 확대하여, 매우 긴 링크 저장 시 발생하던 저장 실패, 잘림, 조회 오류를 방지했습니다.
  * 제안 도면 파일의 도면 URL에도 동일한 제한을 적용해, 외부 스토리지·서드파티 공유 링크 등 긴 URL과의 호환성을 개선하고, 첨부 미리보기/다운로드 동작의 안정성을 높였습니다. 기존 데이터에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->