### PR TITLE
FEAT : 이메일 중복 체크 API를 분리한다.

### DIFF
--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
@@ -1,0 +1,31 @@
+package hanieum.conik.adapter.member.dto;
+
+import hanieum.conik.domain.common.email.Email;
+import hanieum.conik.domain.member.Member;
+import hanieum.conik.domain.member.enumerate.MemberRole;
+
+import java.util.List;
+
+public record MemberInfoResponse(
+        Long id,
+        Email email,
+        String name,
+        String phoneNumber,
+        boolean termsOfServiceAgreed,
+        MemberRole memberType,
+        List<MemberAddressResponse> addresses
+) {
+    public static MemberInfoResponse from(Member member) {
+        return new MemberInfoResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getName(),
+                member.getPhoneNumber(),
+                member.getTermsOfServiceAgreed(),
+                member.getRole(),
+                member.getAddresses().stream()
+                        .map(MemberAddressResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/hanieum/conik/adapter/member/webapi/AuthController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/AuthController.java
@@ -69,16 +69,4 @@ public class AuthController {
         TokenResponse tokenResponse = tokenRefresh.refresh(request.refreshToken());
         return ApiResponse.success(tokenResponse);
     }
-
-    @Operation(
-            summary = "[구현완료] 이메일 중복 확인",
-            description = """
-            ## 이메일 중복 확인을 수행합니다.
-            """
-    )
-    @PostMapping("/email/availability")
-    public ApiResponse<?> checkEmailAvailability(@RequestBody @Valid EmailAvailabilityRequest email) {
-        auth.checkDuplicateEmail(email);
-        return ApiResponse.success("사용 가능한 이메일입니다.");
-    }
 }

--- a/src/main/java/hanieum/conik/adapter/member/webapi/AuthController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/AuthController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 @Validated
 @Tag(name = "AUTH", description = "회원가입/로그인 로직 API")
 public class AuthController {
-
     private final Auth auth;
     private final TokenRefresh tokenRefresh;
 
@@ -69,5 +68,17 @@ public class AuthController {
     ) {
         TokenResponse tokenResponse = tokenRefresh.refresh(request.refreshToken());
         return ApiResponse.success(tokenResponse);
+    }
+
+    @Operation(
+            summary = "[구현완료] 이메일 중복 확인",
+            description = """
+            ## 이메일 중복 확인을 수행합니다.
+            """
+    )
+    @PostMapping("/email/availability")
+    public ApiResponse<?> checkEmailAvailability(@RequestBody @Valid EmailAvailabilityRequest email) {
+        auth.checkDuplicateEmail(email);
+        return ApiResponse.success("사용 가능한 이메일입니다.");
     }
 }

--- a/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
@@ -1,9 +1,11 @@
 package hanieum.conik.adapter.member.webapi;
 
 import hanieum.conik.adapter.member.dto.MemberAddressResponse;
+import hanieum.conik.adapter.member.dto.MemberInfoResponse;
 import hanieum.conik.application.member.provided.MemberFinder;
 import hanieum.conik.application.member.provided.MemberSaver;
 import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
+import hanieum.conik.domain.member.Member;
 import hanieum.conik.domain.member.dto.MemberProfileUpdateRequest;
 import hanieum.conik.domain.member.dto.PasswordChangeRequest;
 import hanieum.conik.global.adapter.security.AuthDetails;
@@ -44,15 +46,27 @@ public class MemberController {
         return ApiResponse.success("회원 정보 수정이 완료되었습니다.");
     }
 
+    @Operation(summary = "내 정보 조회", description = """
+            ## 내 정보를 조회합니다.
+            - 사용자의 기본 정보를 조회할 수 있습니다.
+            """)
+    @GetMapping("/me")
+    public ApiResponse<MemberInfoResponse> getMemberInfo(
+            @AuthenticationPrincipal AuthDetails authDetails
+    ) {
+        Member member = memberFinder.findById(authDetails.getMemberId());
+        return ApiResponse.success(MemberInfoResponse.from(member));
+    }
+
     @Operation(summary = "비밀번호 인증하기", description = """
-    ## 입력한 비밀번호가 현재 비밀번호와 일치하는지 확인합니다.
-    - 사용자가 현재 비밀번호를 인증할 수 있습니다.
-    """)
+            ## 입력한 비밀번호가 현재 비밀번호와 일치하는지 확인합니다.
+            - 사용자가 현재 비밀번호를 인증할 수 있습니다.
+            """)
     @PostMapping("/password")
     public ApiResponse<?> certificatePassword(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestBody @Valid PasswordChangeRequest request
-    ){
+    ) {
         memberSaver.validateCurrentPassword(authDetails.getMemberId(), request.currentPassword());
         return ApiResponse.success("비밀번호 인증이 완료되었습니다.");
     }

--- a/src/main/java/hanieum/conik/application/member/AuthService.java
+++ b/src/main/java/hanieum/conik/application/member/AuthService.java
@@ -27,7 +27,6 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 @RequiredArgsConstructor
 public class AuthService implements Auth, TokenRefresh {
-
     private final MemberRepository memberRepository;
     private final CompanyFinder companyFinder;
     private final MemberFinder memberFinder;
@@ -37,7 +36,7 @@ public class AuthService implements Auth, TokenRefresh {
 
     @Override
     public MemberLoginResponse signUpIndividual(MemberSignUpRequest request) {
-        checkDuplicateEmail(request);
+        checkDuplicateEmail(EmailAvailabilityRequest.from(request.email()));
         Member member = Member.signUpIndividual(getHashedRequest(request));
         memberRepository.save(member);
 
@@ -48,7 +47,7 @@ public class AuthService implements Auth, TokenRefresh {
     public MemberLoginResponse signUpCompanyMember(MemberSignUpRequest request, Long companyId) {
         Company company = companyFinder.findCompany(companyId);
 
-        checkDuplicateEmail(request);
+        checkDuplicateEmail(EmailAvailabilityRequest.from(request.email()));
 
         Member member = Member.signUpCompanyMember(getHashedRequest(request), company.getId());
 
@@ -104,6 +103,13 @@ public class AuthService implements Auth, TokenRefresh {
         );
     }
 
+    @Override
+    public void checkDuplicateEmail(EmailAvailabilityRequest email){
+        if (memberRepository.findByEmail(Email.from(email.email())).isPresent()) {
+            throw new MemberException(MemberErrorType.EMAIL_DUPLICATE);
+        }
+    }
+
     private TokenInfo getTokenInfo(Member member) {
         String accessToken  = jwtTokenProviderPort.createAccessToken(member.getId());
         String refreshToken = jwtTokenProviderPort.createRefreshToken(member.getId());
@@ -111,12 +117,6 @@ public class AuthService implements Auth, TokenRefresh {
         memoryMap.setValue(redisKey, refreshToken, jwtTokenProviderPort.getRefreshTokenExpiration());
 
         return TokenInfo.of(accessToken, refreshToken);
-    }
-
-    private void checkDuplicateEmail(MemberSignUpRequest signUpRequest){
-        if (memberRepository.findByEmail(new Email(signUpRequest.email())).isPresent()) {
-            throw new MemberException(MemberErrorType.EMAIL_DUPLICATE);
-        }
     }
 
     private MemberSignUpRequest getHashedRequest(MemberSignUpRequest request) {

--- a/src/main/java/hanieum/conik/application/member/EmailCertService.java
+++ b/src/main/java/hanieum/conik/application/member/EmailCertService.java
@@ -1,6 +1,8 @@
 package hanieum.conik.application.member;
 
+import hanieum.conik.application.member.provided.Auth;
 import hanieum.conik.application.member.required.EmailSender;
+import hanieum.conik.domain.member.dto.EmailAvailabilityRequest;
 import hanieum.conik.global.application.required.MemoryMap;
 import hanieum.conik.adapter.member.email.dto.AuthCodeRequest;
 import hanieum.conik.adapter.member.email.dto.CertificateRequest;
@@ -15,11 +17,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailCertService{
     private final EmailSender emailSender;
+    private final Auth auth;
     private final MemoryMap memoryMap;
 
     private static final long OTP_TIMEOUT = 5 * 60_000L; // 5분
 
     public void sendEmail(AuthCodeRequest authCodeRequest) {
+        auth.checkDuplicateEmail(EmailAvailabilityRequest.from(authCodeRequest.email()));
+
         int authNumber = emailSender.sendAuthMail(authCodeRequest.email());
         memoryMap.setValue(authCodeRequest.email(), String.valueOf(authNumber), OTP_TIMEOUT);
     }

--- a/src/main/java/hanieum/conik/application/member/MemberFinderService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberFinderService.java
@@ -26,7 +26,7 @@ public class MemberFinderService implements MemberFinder {
 
     @Override
     public Member findById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorType.MEMBER_NOT_FOUND));
+        return memberRepository.findWithAddressesById(memberId).orElseThrow(() -> new MemberException(MemberErrorType.MEMBER_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/hanieum/conik/application/member/provided/Auth.java
+++ b/src/main/java/hanieum/conik/application/member/provided/Auth.java
@@ -1,9 +1,9 @@
 package hanieum.conik.application.member.provided;
 
+import hanieum.conik.domain.member.dto.EmailAvailabilityRequest;
 import hanieum.conik.domain.member.dto.MemberLoginRequest;
 import hanieum.conik.domain.member.dto.MemberLoginResponse;
 import hanieum.conik.domain.member.dto.MemberSignUpRequest;
-import jakarta.validation.Valid;
 
 /**
  * 회원가입/로그인 로직을 구현한다.
@@ -12,4 +12,5 @@ public interface Auth {
     MemberLoginResponse login(MemberLoginRequest loginRequest);
     MemberLoginResponse signUpIndividual(MemberSignUpRequest signUpRequest);
     MemberLoginResponse signUpCompanyMember(MemberSignUpRequest signUpRequest, Long companyId);
+    void checkDuplicateEmail(EmailAvailabilityRequest email);
 }

--- a/src/main/java/hanieum/conik/application/member/required/MemberRepository.java
+++ b/src/main/java/hanieum/conik/application/member/required/MemberRepository.java
@@ -3,9 +3,18 @@ package hanieum.conik.application.member.required;
 import hanieum.conik.domain.member.Member;
 import hanieum.conik.domain.common.email.Email;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    @Query("""
+        select distinct m
+        from Member m
+        left join fetch m.addresses
+        where m.id = :id
+    """)
+    Optional<Member> findWithAddressesById(@Param("id") Long id);
     Optional<Member> findByEmail(Email email);
 }

--- a/src/main/java/hanieum/conik/domain/common/email/Email.java
+++ b/src/main/java/hanieum/conik/domain/common/email/Email.java
@@ -17,4 +17,8 @@ public record Email(String address) {
             throw new MemberException(MemberErrorType.INVALID_EMAIL);
         }
     }
+
+    public static Email from(String email) {
+        return new Email(email);
+    }
 }

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -118,9 +118,6 @@ public class Member extends BaseEntity {
      * 회원 전화번호 수정
      */
     public void updatePhoneNumber(String phoneNumber) {
-        if (phoneNumber == null || phoneNumber.isBlank()) {
-            throw new MemberException(MemberErrorType.INVALID_PHONE_NUMBER);
-        }
         this.phoneNumber = phoneNumber;
     }
 
@@ -128,9 +125,6 @@ public class Member extends BaseEntity {
      * 회원 이름 수정
      */
     public void updateName(String name){
-        if (name == null || name.isBlank()) {
-            throw new MemberException(MemberErrorType.INVALID_NAME);
-        }
         this.name = name;
     }
 

--- a/src/main/java/hanieum/conik/domain/member/dto/EmailAvailabilityRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/EmailAvailabilityRequest.java
@@ -1,0 +1,15 @@
+package hanieum.conik.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailAvailabilityRequest(
+       @NotBlank(message = "이메일은 필수입니다.")
+       @Email(message = "이메일 형식이 아닙니다.")
+       String email
+) {
+    public static EmailAvailabilityRequest from(String email) {
+        return new EmailAvailabilityRequest(email);
+    }
+}
+

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberSignUpRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberSignUpRequest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record MemberSignUpRequest(
         @Schema(description = "사용자 이름", example = "정성호")
@@ -21,6 +22,7 @@ public record MemberSignUpRequest(
         String password,
 
         @Schema(description = "전화번호", example = "010-1234-5678")
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
         @NotBlank(message = "전화번호는 필수입니다.")
         String phoneNumber,
 

--- a/src/main/java/hanieum/conik/global/apiPayload/ApiControllerAdvice.java
+++ b/src/main/java/hanieum/conik/global/apiPayload/ApiControllerAdvice.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import hanieum.conik.global.apiPayload.exception.GlobalErrorType;
 import hanieum.conik.global.apiPayload.response.ApiResponse;
 
+import java.util.Map;
+
 @Slf4j
 @RestControllerAdvice
 public class ApiControllerAdvice {
@@ -22,7 +24,19 @@ public class ApiControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException : {}", e.getMessage(), e);
-        return new ResponseEntity<>(ApiResponse.error(GlobalErrorType.FAILED_REQUEST_VALIDATION), GlobalErrorType.FAILED_REQUEST_VALIDATION.getStatus());
+
+        var fieldError = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .orElse(null);
+
+        GlobalErrorType type = GlobalErrorType.FAILED_REQUEST_VALIDATION;
+
+        if (fieldError != null) {
+            String key = fieldError.getField() + ":" + fieldError.getCode();
+            type = VALIDATION_MAP.getOrDefault(key, GlobalErrorType.FAILED_REQUEST_VALIDATION);
+        }
+
+        return new ResponseEntity<>(ApiResponse.error(type), type.getStatus());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
@@ -37,4 +51,8 @@ public class ApiControllerAdvice {
         return new ResponseEntity<>(ApiResponse.error(e.getErrorType()), e.getErrorType().getStatus());
     }
 
+    private static final Map<String, GlobalErrorType> VALIDATION_MAP = Map.of(
+            "email:NotBlank", GlobalErrorType.EMAIL_REQUIRED,
+            "email:Email",    GlobalErrorType.EMAIL_INVALID_FORMAT
+    );
 }

--- a/src/main/java/hanieum/conik/global/apiPayload/exception/GlobalErrorType.java
+++ b/src/main/java/hanieum/conik/global/apiPayload/exception/GlobalErrorType.java
@@ -23,7 +23,11 @@ public enum GlobalErrorType implements ErrorType {
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다."),
     FAILED_REQUEST_VALIDATION(HttpStatus.BAD_REQUEST, "요청 데이터 검증에 실패하였습니다."),
     INVALID_REQUEST_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 요청 인자입니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다.");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),
+
+    //Email
+    EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "이메일은 필수입니다."),
+    EMAIL_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "이메일 형식이 아닙니다.");
 
     private final HttpStatus status;
 

--- a/src/main/java/hanieum/conik/global/config/SecurityConfig.java
+++ b/src/main/java/hanieum/conik/global/config/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
                                 .requestMatchers(
                                         "/v1/auth/login",
                                         "/v1/email",
-                                        "/v1/email/certificate"
+                                        "/v1/email/certificate",
+                                        "/v1/auth/email/availability"
                                 ).permitAll()
                                 .requestMatchers(
                                         "/swagger-ui.html",

--- a/src/test/java/hanieum/conik/domain/member/service/EmailServiceImplTest.java
+++ b/src/test/java/hanieum/conik/domain/member/service/EmailServiceImplTest.java
@@ -1,6 +1,8 @@
 package hanieum.conik.domain.member.service;
 
+import hanieum.conik.application.member.provided.Auth;
 import hanieum.conik.application.member.required.EmailSender;
+import hanieum.conik.domain.member.dto.EmailAvailabilityRequest;
 import hanieum.conik.domain.member.exception.MemberException;
 import hanieum.conik.global.application.required.MemoryMap;
 import hanieum.conik.adapter.member.email.dto.AuthCodeRequest;
@@ -16,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -24,6 +27,7 @@ import static org.mockito.Mockito.verify;
 class EmailServiceImplTest {
 
     @Mock private EmailSender emailClient;
+    @Mock private Auth auth;
     @Mock private MemoryMap memoryMap;
     @InjectMocks private EmailCertService emailService;
 
@@ -42,15 +46,16 @@ class EmailServiceImplTest {
     @Test
     @DisplayName("이메일 인증 코드 전송 성공")
     void sendEmail_Success() {
-        //given
+        // given
         given(emailClient.sendAuthMail(testEmail)).willReturn(testUserAuthNumber);
 
-        //when
+        // when
         emailService.sendEmail(authCodeRequest);
 
-        //then
+        // then
+        verify(auth).checkDuplicateEmail(eq(EmailAvailabilityRequest.from(testEmail)));
         verify(emailClient).sendAuthMail(testEmail);
-        verify(memoryMap).setValue(testEmail, String.valueOf(testUserAuthNumber), 5 * 60_000L);
+        verify(memoryMap).setValue(eq(testEmail), eq(String.valueOf(testUserAuthNumber)), eq(5 * 60_000L));
     }
 
     @Test


### PR DESCRIPTION
## 💡 관련 이슈
 - #82 


## 📝 작업 내용
- 기존에 회원가인 로직 안에 존재하던 이메일 중복 체크 로직을 따로 분리하였습니다.(기존 회원가입 로직에는 그대로 유지)
- 이메일 형식 체크가 Request DTO에서 @Valid로 검증을 하고 있었는데, 이때 형식 에러가 발생하면 응답값으로는 500에러만 나오고 Global Error Message만 출력이 되고 @Valid에 있는 에러 메시지는 출력되지 않았습니다.
- 그래서 ApiControllerAdvice를 수정하여 @Valid 에서 로그로만 보내던 에러 메시지를 응답값으로도 보낼 수 있도록 수정하였습니다.


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 이메일 사용 가능 여부 확인 API 추가: POST /v1/auth/email/availability (인증 불필요)
  - 내 정보 조회 API 추가: GET /v1/member/me (회원 정보 및 주소 포함)

- Bug Fixes
  - 이메일 검증 응답 개선: 필수/형식 오류별로 구체적 코드·메시지 반환
  - 가입 폼 전화번호 검증 강화: 010-XXXX-XXXX 패턴 적용
  - 가입 및 인증 메일 발송 시 이메일 중복 검사 도입
  - 회원 정보 수정 시 이름/전화번호 입력 검증이 완화됨

- Chores
  - 이메일 확인 경로를 공개 엔드포인트로 허용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->