### PR TITLE
FEAT : 회원가입시 보이는 기업 summary 목록 조회에서 이름, 지역, 업종명으로 검색/필터링 가능하도록 변경

### DIFF
--- a/src/main/java/hanieum/conik/adapter/company/webapi/CompanyController.java
+++ b/src/main/java/hanieum/conik/adapter/company/webapi/CompanyController.java
@@ -8,6 +8,7 @@ import hanieum.conik.application.company.provided.CompanyFinder;
 import hanieum.conik.application.company.provided.CompanySaver;
 import hanieum.conik.domain.company.dto.CompanyDetailCreateRequest;
 import hanieum.conik.domain.company.dto.CompanyProfileSearchCondition;
+import hanieum.conik.domain.company.dto.CompanySummarySearchCondition;
 import hanieum.conik.domain.company.entity.Company;
 import hanieum.conik.domain.company.dto.CompanyRegisterRequest;
 import hanieum.conik.global.adapter.security.AuthDetails;
@@ -46,15 +47,17 @@ public class CompanyController {
         return ApiResponse.success(companySaver.register(request));
     }
 
-    @Operation(summary = "전체 기업 summary 조회", description = """
-    ## 기업 회원 가입 시 전체 기업 조회를 수행합니다.
-    - 등록되어있는 모든 기업을 조회할 수 있습니다.
-    - 기업명, 업종, 대표자, 사업자 등록번호, 주소 정보를 확인할 수 있습니다.
+    @Operation(summary = "기업 summary 조회(이름, 지역, 업종명)", description = """
+    ## 회원가입시 기업의 요약 정보를 조회합니다.
+    - 기업의 이름, 지역, 업종명 등의 요약 정보를 조회합니다.
+    - 페이징 처리가 적용되어 있습니다.
+    - 정렬은 생성일자 내림차순으로 고정되어 있습니다.
     """)
     @GetMapping("/summaries")
-    public ApiResponse<Page<CompanySummaryResponse>> findAllCompaniesSummary(
+    public ApiResponse<Page<CompanySummaryResponse>> findCompaniesSummary(
+            @ParameterObject CompanySummarySearchCondition cond,
             @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        return ApiResponse.success(companyFinder.findAllCompanySummaries(pageable));
+        return ApiResponse.success(companyFinder.searchCompanySummaries(cond, pageable));
     }
 
     @Operation(summary = "특정 기업 조회", description = """

--- a/src/main/java/hanieum/conik/application/company/CompanyFinderService.java
+++ b/src/main/java/hanieum/conik/application/company/CompanyFinderService.java
@@ -9,6 +9,7 @@ import hanieum.conik.application.company.required.EquipmentRepository;
 import hanieum.conik.application.company.required.PortfolioRepository;
 import hanieum.conik.application.member.provided.MemberFinder;
 import hanieum.conik.domain.company.dto.CompanyProfileSearchCondition;
+import hanieum.conik.domain.company.dto.CompanySummarySearchCondition;
 import hanieum.conik.domain.company.entity.Company;
 import hanieum.conik.domain.company.entity.Equipment;
 import hanieum.conik.domain.company.entity.Portfolio;
@@ -26,7 +27,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class CompanyFinderService implements CompanyFinder {
     private final MemberFinder memberFinder;
     private final CompanyRepository companyRepository;
@@ -34,7 +35,6 @@ public class CompanyFinderService implements CompanyFinder {
     private final PortfolioRepository portfolioRepository;
 
     @Override
-    @Transactional(readOnly = true)
     public Page<CompanySummaryResponse> findAllCompanySummaries(Pageable pageable) {
         validatePageable(pageable);
 
@@ -43,14 +43,18 @@ public class CompanyFinderService implements CompanyFinder {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Company findCompany(Long companyId) {
         return companyRepository.findById(companyId)
                 .orElseThrow(() -> new CompanyException(CompanyErrorType.COMPANY_NOT_FOUND));
     }
 
     @Override
-    @Transactional(readOnly = true)
+    public Page<CompanySummaryResponse> searchCompanySummaries(CompanySummarySearchCondition cond, Pageable pageable) {
+        Page<Company> search = companyRepository.search(cond, pageable);
+        return search.map(CompanySummaryResponse::from);
+    }
+
+    @Override
     public CompanyDetailResponse findMyCompanyWithDetail(Long memberId){
         Member member = memberFinder.findById(memberId);
 
@@ -72,7 +76,6 @@ public class CompanyFinderService implements CompanyFinder {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<Company> findCompaniesByIds(Collection<Long> ids) {
         if (ids == null || ids.isEmpty()) {
             return List.of();
@@ -81,7 +84,6 @@ public class CompanyFinderService implements CompanyFinder {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public CompanyDetailResponse findCompanyWithDetail(Long companyId) {
         Company company = companyRepository.findWithDetailById(companyId)
                 .orElseThrow(() -> new CompanyException(CompanyErrorType.COMPANY_NOT_FOUND));
@@ -101,7 +103,6 @@ public class CompanyFinderService implements CompanyFinder {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Page<CompanyProfileResponse> findAllCompanyWithFilter(CompanyProfileSearchCondition cond, Pageable pageable) {
         validatePageable(pageable);
 

--- a/src/main/java/hanieum/conik/application/company/CompanyFinderService.java
+++ b/src/main/java/hanieum/conik/application/company/CompanyFinderService.java
@@ -50,6 +50,7 @@ public class CompanyFinderService implements CompanyFinder {
 
     @Override
     public Page<CompanySummaryResponse> searchCompanySummaries(CompanySummarySearchCondition cond, Pageable pageable) {
+        validatePageable(pageable);
         Page<Company> search = companyRepository.search(cond, pageable);
         return search.map(CompanySummaryResponse::from);
     }

--- a/src/main/java/hanieum/conik/application/company/provided/CompanyFinder.java
+++ b/src/main/java/hanieum/conik/application/company/provided/CompanyFinder.java
@@ -4,6 +4,7 @@ import hanieum.conik.adapter.company.webapi.response.CompanyDetailResponse;
 import hanieum.conik.adapter.company.webapi.response.CompanyProfileResponse;
 import hanieum.conik.adapter.company.webapi.response.CompanySummaryResponse;
 import hanieum.conik.domain.company.dto.CompanyProfileSearchCondition;
+import hanieum.conik.domain.company.dto.CompanySummarySearchCondition;
 import hanieum.conik.domain.company.entity.Company;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,6 +19,8 @@ public interface CompanyFinder {
     Page<CompanySummaryResponse> findAllCompanySummaries(Pageable pageable);
 
     Company findCompany(Long companyId);
+
+    Page<CompanySummaryResponse> searchCompanySummaries(CompanySummarySearchCondition cond, Pageable pageable);
 
     CompanyDetailResponse findMyCompanyWithDetail(Long memberId);
 

--- a/src/main/java/hanieum/conik/application/company/required/CompanyRepositoryCustom.java
+++ b/src/main/java/hanieum/conik/application/company/required/CompanyRepositoryCustom.java
@@ -2,9 +2,12 @@ package hanieum.conik.application.company.required;
 
 import hanieum.conik.adapter.company.webapi.response.CompanyProfileResponse;
 import hanieum.conik.domain.company.dto.CompanyProfileSearchCondition;
+import hanieum.conik.domain.company.dto.CompanySummarySearchCondition;
+import hanieum.conik.domain.company.entity.Company;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CompanyRepositoryCustom {
     Page<CompanyProfileResponse> findCompaniesWithFilter(CompanyProfileSearchCondition cond, Pageable pageable);
+    Page<Company> search(CompanySummarySearchCondition cond, Pageable pageable);
 }

--- a/src/main/java/hanieum/conik/application/company/required/CompanyRepositoryImpl.java
+++ b/src/main/java/hanieum/conik/application/company/required/CompanyRepositoryImpl.java
@@ -4,9 +4,12 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import hanieum.conik.adapter.company.webapi.response.CompanyProfileResponse;
 import hanieum.conik.domain.company.dto.CompanyProfileSearchCondition;
+import hanieum.conik.domain.company.dto.CompanySummarySearchCondition;
+import hanieum.conik.domain.company.entity.Company;
 import hanieum.conik.domain.company.entity.QCompany;
 import hanieum.conik.domain.company.entity.QCompanyDetail;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +17,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -92,4 +97,62 @@ public class CompanyRepositoryImpl implements CompanyRepositoryCustom{
         }
         return list.toArray(OrderSpecifier[]::new);
     }
+
+    @Override
+    public Page<Company> search(CompanySummarySearchCondition cond, Pageable pageable) {
+        QCompany c = QCompany.company;
+        QCompanyDetail d = QCompanyDetail.companyDetail;
+
+        BooleanBuilder where = new BooleanBuilder();
+
+        if (cond != null) {
+            if (org.springframework.util.StringUtils.hasText(cond.name())) {
+                where.and(c.name.containsIgnoreCase(cond.name().trim()));
+            }
+            if (org.springframework.util.StringUtils.hasText(cond.region())) {
+                String kw = cond.region().trim();
+                where.and(
+                        c.address.streetAddress.containsIgnoreCase(kw)
+                                .or(c.address.detailAddress.containsIgnoreCase(kw))
+                );
+            }
+            if (org.springframework.util.StringUtils.hasText(cond.businessType())) {
+                where.and(c.businessType.containsIgnoreCase(cond.businessType().trim()));
+            }
+        }
+
+        JPAQuery<Company> contentQuery = qf
+                .selectFrom(c)
+                .leftJoin(c.companyDetail, d).fetchJoin()
+                .where(where)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        if (pageable.getSort().isEmpty()) {
+            contentQuery.orderBy(c.name.asc());
+        } else {
+            for (Sort.Order order : pageable.getSort()) {
+                String prop = order.getProperty();
+                boolean asc = order.isAscending();
+
+                if ("name".equalsIgnoreCase(prop)) {
+                    contentQuery.orderBy(asc ? c.name.asc() : c.name.desc());
+                } else if ("createdAt".equalsIgnoreCase(prop)) {
+                    contentQuery.orderBy(asc ? c.createdAt.asc() : c.createdAt.desc());
+                } else if ("businessType".equalsIgnoreCase(prop)) {
+                    contentQuery.orderBy(asc ? c.businessType.asc() : c.businessType.desc());
+                }
+            }
+        }
+
+        List<Company> content = contentQuery.fetch();
+
+        JPAQuery<Long> countQuery = qf
+                .select(c.count())
+                .from(c)
+                .where(where);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
 }

--- a/src/main/java/hanieum/conik/domain/company/dto/CompanySummarySearchCondition.java
+++ b/src/main/java/hanieum/conik/domain/company/dto/CompanySummarySearchCondition.java
@@ -1,0 +1,16 @@
+package hanieum.conik.domain.company.dto;
+
+public record CompanySummarySearchCondition(
+        String name,
+        String region,
+        String businessType // String 대신 Enum이면 더 안전
+) {
+    public static CompanySummarySearchCondition of(String name, String region, String businessType) {
+        return new CompanySummarySearchCondition(
+                trimToNull(name),
+                trimToNull(region),
+                trimToNull(businessType)
+        );
+    }
+    private static String trimToNull(String s) { return (s == null || s.isBlank()) ? null : s.trim(); }
+}

--- a/src/test/java/hanieum/conik/application/company/CompanyFinderServiceTest.java
+++ b/src/test/java/hanieum/conik/application/company/CompanyFinderServiceTest.java
@@ -1,0 +1,355 @@
+package hanieum.conik.application.company;
+
+import hanieum.conik.adapter.company.webapi.response.CompanyDetailResponse;
+import hanieum.conik.adapter.company.webapi.response.CompanyProfileResponse;
+import hanieum.conik.adapter.company.webapi.response.CompanySummaryResponse;
+import hanieum.conik.application.company.required.CompanyRepository;
+import hanieum.conik.application.company.required.EquipmentRepository;
+import hanieum.conik.application.company.required.PortfolioRepository;
+import hanieum.conik.application.member.provided.MemberFinder;
+import hanieum.conik.domain.company.dto.CompanyProfileSearchCondition;
+import hanieum.conik.domain.company.dto.CompanySummarySearchCondition;
+import hanieum.conik.domain.company.entity.Company;
+import hanieum.conik.domain.company.entity.CompanyDetail;
+import hanieum.conik.domain.company.exception.CompanyException;
+import hanieum.conik.domain.member.Member;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Transactional
+class CompanyFinderServiceTest {
+    @Autowired
+    CompanyFinderService service;
+
+    @MockBean
+    MemberFinder memberFinder;
+    @MockBean
+    CompanyRepository companyRepository;
+    @MockBean
+    EquipmentRepository equipmentRepository;
+    @MockBean
+    PortfolioRepository portfolioRepository;
+
+    // ─────────────────────────── findAllCompanySummaries ───────────────────────────
+
+    @Test
+    @DisplayName("전체 기업 summary 조회: 빈 페이지 반환")
+    void findAllCompanySummaries_returnsEmptyPage() {
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        given(companyRepository.findAll(pageable))
+                .willReturn(new PageImpl<>(Collections.emptyList(), pageable, 0));
+
+        Page<CompanySummaryResponse> page = service.findAllCompanySummaries(pageable);
+
+        assertThat(page).isNotNull();
+        assertThat(page.getTotalElements()).isZero();
+        verify(companyRepository).findAll(pageable);
+    }
+
+    @Test
+    @DisplayName("전체 기업 summary 조회: PageRequest 자체 검증 + 서비스 상한 검증")
+    void findAllCompanySummaries_invalidPageable_throws() {
+        assertThatThrownBy(() -> PageRequest.of(-1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Page index must not be less than zero");
+
+        assertThatThrownBy(() -> PageRequest.of(0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Page size must not be less than one");
+
+        Pageable tooLarge = PageRequest.of(0, 201);
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> service.findAllCompanySummaries(tooLarge))
+                .isInstanceOf(CompanyException.class);
+    }
+
+    // ─────────────────────────── findCompany ───────────────────────────
+
+    @Test
+    @DisplayName("기업 단건 조회: 존재하면 반환")
+    void findCompany_found() {
+        Long id = 1L;
+        Company company = mock(Company.class);
+        given(companyRepository.findById(id)).willReturn(Optional.of(company));
+
+        Company result = service.findCompany(id);
+
+        assertThat(result).isSameAs(company);
+        verify(companyRepository).findById(id);
+    }
+
+    @Test
+    @DisplayName("기업 단건 조회: 없으면 예외")
+    void findCompany_notFound_throws() {
+        Long id = 999L;
+        given(companyRepository.findById(id)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.findCompany(id))
+                .isInstanceOf(CompanyException.class);
+    }
+
+    // ─────────────────────────── searchCompanySummaries ───────────────────────────
+
+    @Test
+    @DisplayName("기업명/지역/업종 검색 summary: Repository.search 위임")
+    void searchCompanySummaries_delegates() {
+        // given
+        CompanySummarySearchCondition cond = new CompanySummarySearchCondition("삼성", null, null);
+        Pageable pageable = PageRequest.of(0, 10);
+        given(companyRepository.search(cond, pageable))
+                .willReturn(new PageImpl<>(Collections.emptyList(), pageable, 0));
+
+        // when
+        Page<CompanySummaryResponse> page = service.searchCompanySummaries(cond, pageable);
+
+        // then
+        assertThat(page).isNotNull();
+        assertThat(page.getTotalElements()).isZero();
+        verify(companyRepository).search(cond, pageable);
+    }
+
+    @Test
+    @DisplayName("1) 아무것도 검색하지 않은 경우(전체 조회 동작) - cond가 모두 null")
+    void searchCompanySummaries_allNull_returnsAll() {
+        // given
+        CompanySummarySearchCondition cond = new CompanySummarySearchCondition(null, null, null);
+        Pageable pageable = PageRequest.of(0, 10);
+        given(companyRepository.search(cond, pageable))
+                .willReturn(new PageImpl<>(Collections.emptyList(), pageable, 0));
+
+        // when
+        var page = service.searchCompanySummaries(cond, pageable);
+
+        // then
+        assertThat(page.getTotalElements()).isZero();
+        verify(companyRepository).search(cond, pageable);
+    }
+
+    @Test
+    @DisplayName("2) 이름만 검색한 경우")
+    void searchCompanySummaries_nameOnly() {
+        // given
+        CompanySummarySearchCondition cond = new CompanySummarySearchCondition("삼성", null, null);
+        Pageable pageable = PageRequest.of(0, 10);
+        given(companyRepository.search(cond, pageable))
+                .willReturn(new PageImpl<>(Collections.emptyList(), pageable, 0));
+
+        // when
+        var page = service.searchCompanySummaries(cond, pageable);
+
+        // then
+        assertThat(page.getTotalElements()).isZero();
+        verify(companyRepository).search(cond, pageable);
+    }
+
+    @Test
+    @DisplayName("3) 지역으로만 필터링한 경우")
+    void searchCompanySummaries_regionOnly() {
+        // given
+        CompanySummarySearchCondition cond = new CompanySummarySearchCondition(null, "서울", null);
+        Pageable pageable = PageRequest.of(0, 10);
+        given(companyRepository.search(cond, pageable))
+                .willReturn(new PageImpl<>(Collections.emptyList(), pageable, 0));
+
+        // when
+        var page = service.searchCompanySummaries(cond, pageable);
+
+        // then
+        assertThat(page.getTotalElements()).isZero();
+        verify(companyRepository).search(cond, pageable);
+    }
+
+    @Test
+    @DisplayName("4) 업종명으로만 필터링한 경우")
+    void searchCompanySummaries_businessTypeOnly() {
+        // given
+        CompanySummarySearchCondition cond = new CompanySummarySearchCondition(null, null, "제조");
+        Pageable pageable = PageRequest.of(0, 10);
+        given(companyRepository.search(cond, pageable))
+                .willReturn(new PageImpl<>(Collections.emptyList(), pageable, 0));
+
+        // when
+        var page = service.searchCompanySummaries(cond, pageable);
+
+        // then
+        assertThat(page.getTotalElements()).isZero();
+        verify(companyRepository).search(cond, pageable);
+    }
+
+    @Test
+    @DisplayName("5) 이름/지역/업종을 섞어서 조회한 경우")
+    void searchCompanySummaries_mixed() {
+        // given
+        CompanySummarySearchCondition cond = new CompanySummarySearchCondition("삼", "경기", "가공");
+        Pageable pageable = PageRequest.of(0, 10);
+        given(companyRepository.search(cond, pageable))
+                .willReturn(new PageImpl<>(Collections.emptyList(), pageable, 0));
+
+        // when
+        var page = service.searchCompanySummaries(cond, pageable);
+
+        // then
+        assertThat(page.getTotalElements()).isZero();
+        verify(companyRepository).search(cond, pageable);
+    }
+
+    // ─────────────────────────── findMyCompanyWithDetail ───────────────────────────
+
+    @Test
+    @DisplayName("내 기업 상세 조회: 상세가 없으면 CompanyOnly 응답, 장비/포트폴리오 조회 안함")
+    void findMyCompanyWithDetail_noDetail_returnsCompanyOnly() {
+        Long memberId = 3L;
+        Long companyId = 10L;
+
+        Member member = mock(Member.class);
+        given(member.getCompanyId()).willReturn(companyId);
+        given(memberFinder.findById(memberId)).willReturn(member);
+
+        Company company = mock(Company.class);
+        given(company.getId()).willReturn(companyId);
+        given(company.getCompanyDetail()).willReturn(null);
+        given(companyRepository.findById(companyId)).willReturn(Optional.of(company));
+
+        CompanyDetailResponse res = service.findMyCompanyWithDetail(memberId);
+
+        assertThat(res).isNotNull();
+        verify(equipmentRepository, never()).findByCompanyDetailId(anyLong());
+        verify(portfolioRepository, never()).findByCompanyDetailId(anyLong());
+    }
+
+    @Test
+    @DisplayName("내 기업 상세 조회: 상세가 있으면 장비/포트폴리오까지 조회")
+    void findMyCompanyWithDetail_withDetail_fetchLists() {
+        Long memberId = 5L;
+        Long companyId = 22L;
+
+        Member member = mock(Member.class);
+        given(member.getCompanyId()).willReturn(companyId);
+        given(memberFinder.findById(memberId)).willReturn(member);
+
+        CompanyDetail detail = mock(CompanyDetail.class);
+        Company company = mock(Company.class);
+        given(company.getId()).willReturn(companyId);
+        given(company.getCompanyDetail()).willReturn(detail);
+        given(companyRepository.findById(companyId)).willReturn(Optional.of(company));
+
+        given(equipmentRepository.findByCompanyDetailId(anyLong())).willReturn(List.of());
+        given(portfolioRepository.findByCompanyDetailId(anyLong())).willReturn(List.of());
+
+        CompanyDetailResponse res = service.findMyCompanyWithDetail(memberId);
+
+        assertThat(res).isNotNull();
+        // 구현 상 companyId로 조회(또는 detailId) – 인자 검증이 필요하면 ArgumentCaptor 사용
+        verify(equipmentRepository).findByCompanyDetailId(anyLong());
+        verify(portfolioRepository).findByCompanyDetailId(anyLong());
+    }
+
+    // ─────────────────────────── findCompanyWithDetail ───────────────────────────
+
+    @Test
+    @DisplayName("기업 상세 단건 조회: 없으면 예외")
+    void findCompanyWithDetail_notFound_throws() {
+        Long id = 100L;
+        given(companyRepository.findWithDetailById(id)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.findCompanyWithDetail(id))
+                .isInstanceOf(CompanyException.class);
+    }
+
+    @Test
+    @DisplayName("기업 상세 단건 조회: 상세가 null이면 예외")
+    void findCompanyWithDetail_detailNull_throws() {
+        Long id = 100L;
+        Company company = mock(Company.class);
+        given(company.getCompanyDetail()).willReturn(null);
+        given(companyRepository.findWithDetailById(id)).willReturn(Optional.of(company));
+
+        assertThatThrownBy(() -> service.findCompanyWithDetail(id))
+                .isInstanceOf(CompanyException.class);
+    }
+
+    @Test
+    @DisplayName("기업 상세 단건 조회: 상세가 있으면 장비/포트폴리오까지 조회")
+    void findCompanyWithDetail_ok() {
+        Long id = 77L;
+        Company company = mock(Company.class);
+        CompanyDetail detail = mock(CompanyDetail.class);
+        given(company.getCompanyDetail()).willReturn(detail);
+        given(companyRepository.findWithDetailById(id)).willReturn(Optional.of(company));
+
+        given(equipmentRepository.findByCompanyDetailId(id)).willReturn(List.of());
+        given(portfolioRepository.findByCompanyDetailId(id)).willReturn(List.of());
+
+        CompanyDetailResponse res = service.findCompanyWithDetail(id);
+
+        assertThat(res).isNotNull();
+        verify(equipmentRepository).findByCompanyDetailId(id);
+        verify(portfolioRepository).findByCompanyDetailId(id);
+    }
+
+    // ─────────────────────────── findCompaniesByIds ───────────────────────────
+
+    @Test
+    @DisplayName("ID 컬렉션이 null/empty면 빈 리스트 반환하고 레포 호출 안함")
+    void findCompaniesByIds_nullOrEmpty_returnsEmpty() {
+        assertThat(service.findCompaniesByIds(null)).isEmpty();
+        assertThat(service.findCompaniesByIds(List.of())).isEmpty();
+        verify(companyRepository, never()).findByIdIn(anyCollection());
+    }
+
+    @Test
+    @DisplayName("ID 컬렉션이 있으면 findByIdIn 위임")
+    void findCompaniesByIds_nonEmpty_delegates() {
+        List<Long> ids = List.of(1L, 2L, 3L);
+        List<Company> expected = List.of(mock(Company.class));
+        given(companyRepository.findByIdIn(ids)).willReturn(expected);
+
+        List<Company> actual = service.findCompaniesByIds(ids);
+
+        assertThat(actual).isSameAs(expected);
+        verify(companyRepository).findByIdIn(ids);
+    }
+
+    // ─────────────────────────── findAllCompanyWithFilter ───────────────────────────
+
+    @Test
+    @DisplayName("프로필 목록 조회(필터): Pageable 검증 및 레포 위임")
+    void findAllCompanyWithFilter_delegates() {
+        Pageable pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "rating"));
+        CompanyProfileSearchCondition cond = new CompanyProfileSearchCondition(null, null, null, null, null);
+
+        // 레포가 DTO 페이지를 직접 반환하는 시그니처
+        Page<CompanyProfileResponse> repoPage = new PageImpl<>(List.of(), pageable, 0);
+        given(companyRepository.findCompaniesWithFilter(cond, pageable)).willReturn(repoPage);
+
+        Page<CompanyProfileResponse> result = service.findAllCompanyWithFilter(cond, pageable);
+
+        assertThat(result.getTotalElements()).isZero();
+        verify(companyRepository).findCompaniesWithFilter(cond, pageable);
+    }
+
+    @Test
+    @DisplayName("프로필 목록 조회(필터): 잘못된 Pageable이면 예외")
+    void findAllCompanyWithFilter_invalidPageable_throws() {
+        CompanyProfileSearchCondition cond = new CompanyProfileSearchCondition(null, null, null, null, null);
+        assertThatThrownBy(() -> PageRequest.of(0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Page size must not be less than one");
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- #83 


## 📝 작업 내용
- 회원가입시 기업 summary 조회에서 이름, 지역, 업종명을 통해 검색/필터링이 가능하도록 변경하였음


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 회사 요약 목록 API에 이름·지역·업종 기반 필터 검색 추가. 여러 조건을 조합해 페이지네이션과 함께 조회 가능.
  * 검색 결과의 정렬·필터링 및 페이징 처리 향상으로 더 정확한 목록 반환.
* 문서
  * API 문서에 필터 파라미터와 페이징 동작 설명 및 예시 보강.
* 테스트
  * 서비스 단위 테스트를 확대해 다양한 필터 조합, 빈 결과, 예외 상황 및 페이징 경계 조건을 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->