### PR TITLE
FEAT : 주소 엔티티에 필드 추가, 기본 배송지 설정

### DIFF
--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberAddressResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberAddressResponse.java
@@ -6,14 +6,20 @@ public record MemberAddressResponse(
         Long id,
         String postalCode,
         String streetAddress,
-        String detailAddress
+        String detailAddress,
+        String addressName,
+        String recipient,
+        String phoneNumber
 ) {
     public static MemberAddressResponse from(MemberAddress address) {
         return new MemberAddressResponse(
                 address.getId(),
                 address.getPostalCode(),
                 address.getStreetAddress(),
-                address.getDetailAddress()
+                address.getDetailAddress(),
+                address.getAddressName(),
+                address.getRecipient(),
+                address.getPhoneNumber()
         );
     }
 }

--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
@@ -2,6 +2,7 @@ package hanieum.conik.adapter.member.dto;
 
 import hanieum.conik.domain.common.email.Email;
 import hanieum.conik.domain.member.Member;
+import hanieum.conik.domain.member.MemberAddress;
 import hanieum.conik.domain.member.enumerate.MemberRole;
 
 import java.util.List;
@@ -13,7 +14,8 @@ public record MemberInfoResponse(
         String phoneNumber,
         boolean termsOfServiceAgreed,
         MemberRole memberType,
-        List<MemberAddressResponse> addresses
+        List<MemberAddressResponse> addresses,
+        MemberAddressResponse defaultAddress
 ) {
     public static MemberInfoResponse from(Member member) {
         return new MemberInfoResponse(
@@ -25,7 +27,8 @@ public record MemberInfoResponse(
                 member.getRole(),
                 member.getAddresses().stream()
                         .map(MemberAddressResponse::from)
-                        .toList()
+                        .toList(),
+                MemberAddressResponse.from(member.getDefaultAddress())
         );
     }
 }

--- a/src/main/java/hanieum/conik/application/company/required/CompanyRepositoryImpl.java
+++ b/src/main/java/hanieum/conik/application/company/required/CompanyRepositoryImpl.java
@@ -86,7 +86,7 @@ public class CompanyRepositoryImpl implements CompanyRepositoryCustom{
         List<OrderSpecifier<?>> list = new ArrayList<>();
         for (Sort.Order o : sort) {
             ComparableExpressionBase<?> path = switch (o.getProperty()) {
-                case "addressName"                   -> c.name;
+                case "name"                   -> c.name;
                 case "rating"                 -> d.rating;
                 case "avgResponseMinutes"     -> d.avgResponseMinutes;
                 case "totalOrderCount"        -> d.totalOrderCount;

--- a/src/main/java/hanieum/conik/application/company/required/CompanyRepositoryImpl.java
+++ b/src/main/java/hanieum/conik/application/company/required/CompanyRepositoryImpl.java
@@ -86,7 +86,7 @@ public class CompanyRepositoryImpl implements CompanyRepositoryCustom{
         List<OrderSpecifier<?>> list = new ArrayList<>();
         for (Sort.Order o : sort) {
             ComparableExpressionBase<?> path = switch (o.getProperty()) {
-                case "name"                   -> c.name;
+                case "addressName"                   -> c.name;
                 case "rating"                 -> d.rating;
                 case "avgResponseMinutes"     -> d.avgResponseMinutes;
                 case "totalOrderCount"        -> d.totalOrderCount;
@@ -135,7 +135,7 @@ public class CompanyRepositoryImpl implements CompanyRepositoryCustom{
                 String prop = order.getProperty();
                 boolean asc = order.isAscending();
 
-                if ("name".equalsIgnoreCase(prop)) {
+                if ("addressName".equalsIgnoreCase(prop)) {
                     contentQuery.orderBy(asc ? c.name.asc() : c.name.desc());
                 } else if ("createdAt".equalsIgnoreCase(prop)) {
                     contentQuery.orderBy(asc ? c.createdAt.asc() : c.createdAt.desc());

--- a/src/main/java/hanieum/conik/application/member/MemberModifyService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberModifyService.java
@@ -54,7 +54,7 @@ public class MemberModifyService implements MemberSaver {
     public void addAddress(Long memberId, AddressRegisterRequest request) {
         Member member = memberFinder.findById(memberId);
         MemberAddress address = MemberAddress.register(request);
-        member.addAddress(address);
+        member.addAddress(address, request.isDefault());
     }
 
     @Override

--- a/src/main/java/hanieum/conik/application/member/required/MemberRepository.java
+++ b/src/main/java/hanieum/conik/application/member/required/MemberRepository.java
@@ -13,6 +13,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         select distinct m
         from Member m
         left join fetch m.addresses
+        left join fetch m.defaultAddress d
         where m.id = :id
     """)
     Optional<Member> findWithAddressesById(@Param("id") Long id);

--- a/src/main/java/hanieum/conik/domain/common/address/AddressBase.java
+++ b/src/main/java/hanieum/conik/domain/common/address/AddressBase.java
@@ -1,10 +1,8 @@
 package hanieum.conik.domain.common.address;
 
-import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
-import hanieum.conik.domain.common.address.exception.AddressErrorType;
-import hanieum.conik.domain.common.address.exception.AddressException;
 import hanieum.conik.global.domain.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,6 +15,16 @@ public class AddressBase extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "address_name",nullable = false, length = 50)
+    private String addressName;
+
+    @Column(nullable = false, length = 50)
+    private String recipient;
+
+    @Column(nullable = false, length = 20)
+    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+    private String phoneNumber;
+
     @Column(nullable = false)
     private String postalCode;
 
@@ -26,27 +34,12 @@ public class AddressBase extends BaseEntity {
     @Column(nullable = false)
     private String detailAddress;
 
-    protected AddressBase(String postalCode, String streetAddress, String detailAddress) {
+    protected AddressBase(String postalCode, String streetAddress, String detailAddress, String addressName, String recipient, String phoneNumber) {
         this.postalCode = postalCode;
         this.streetAddress = streetAddress;
         this.detailAddress = detailAddress;
-    }
-
-    /**
-     * 주소 정보를 업데이트 한다.
-     */
-    public void update(AddressRegisterRequest request) {
-        if (request.postalCode() == null || request.postalCode().isBlank()) {
-            throw new AddressException(AddressErrorType.INVALID_POSTAL_CODE);
-        }
-        if (request.streetAddress() == null || request.streetAddress().isBlank()) {
-            throw new AddressException(AddressErrorType.INVALID_STREET_ADDRESS);
-        }
-        if (request.detailAddress() == null || request.detailAddress().isBlank()) {
-            throw new AddressException(AddressErrorType.INVALID_DETAIL_ADDRESS);
-        }
-        this.postalCode = request.postalCode();
-        this.streetAddress = request.streetAddress();
-        this.detailAddress = request.detailAddress();
+        this.addressName = addressName;
+        this.recipient = recipient;
+        this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/hanieum/conik/domain/common/address/dto/AddressRegisterRequest.java
+++ b/src/main/java/hanieum/conik/domain/common/address/dto/AddressRegisterRequest.java
@@ -1,9 +1,25 @@
 package hanieum.conik.domain.common.address.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 public record AddressRegisterRequest(
+        @Schema(description = "배송지명", example = "우리집")
+        @NotBlank(message = "배송지명은 필수 입력입니다.")
+        String addressName,
+
+        @Schema(description = "수령인", example = "홍길동")
+        @NotBlank(message = "수령인은 필수 입력입니다.")
+        String recipient,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+        @NotBlank(message = "전화번호는 필수 입력입니다.")
+        String phoneNumber,
+
         @Schema(description = "우편번호", example = "12345")
         @NotBlank(message = "우편번호는 필수 입력입니다.")
         String postalCode,
@@ -14,5 +30,10 @@ public record AddressRegisterRequest(
 
         @Schema(description = "상세 주소", example = "행복호")
         @NotBlank(message = "상세 주소는 필수 입력입니다.")
-        String detailAddress
+        String detailAddress,
+
+        @Schema(description = "기본 배송지 여부", example = "false")
+        @JsonProperty("default")
+        @NotNull
+        boolean isDefault
 ) {}

--- a/src/main/java/hanieum/conik/domain/common/address/dto/AddressRegisterRequest.java
+++ b/src/main/java/hanieum/conik/domain/common/address/dto/AddressRegisterRequest.java
@@ -16,7 +16,6 @@ public record AddressRegisterRequest(
         String recipient,
 
         @Schema(description = "전화번호", example = "010-1234-5678")
-        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
         @NotBlank(message = "전화번호는 필수 입력입니다.")
         String phoneNumber,
 

--- a/src/main/java/hanieum/conik/domain/common/address/dto/AddressRegisterRequest.java
+++ b/src/main/java/hanieum/conik/domain/common/address/dto/AddressRegisterRequest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 
 public record AddressRegisterRequest(
         @Schema(description = "배송지명", example = "우리집")

--- a/src/main/java/hanieum/conik/domain/common/address/exception/AddressErrorType.java
+++ b/src/main/java/hanieum/conik/domain/common/address/exception/AddressErrorType.java
@@ -8,6 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AddressErrorType implements ErrorType {
+    INVALID_NAME(HttpStatus.BAD_REQUEST, "주소 이름은 필수입니다."),
+    INVALID_RECIPIENT(HttpStatus.BAD_REQUEST, "수령인 이름은 필수입니다."),
+    INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "전화번호는 필수입니다."),
     INVALID_POSTAL_CODE(HttpStatus.BAD_REQUEST, "우편번호는 필수입니다."),
     INVALID_STREET_ADDRESS(HttpStatus.BAD_REQUEST, "도로명 주소는 필수입니다."),
     INVALID_DETAIL_ADDRESS(HttpStatus.BAD_REQUEST, "상세 주소는 필수입니다.")

--- a/src/main/java/hanieum/conik/domain/company/entity/Company.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/Company.java
@@ -92,7 +92,7 @@ public class Company extends BaseEntity {
                 request.registrationCertificateUrl(),
                 request.profileUrl(),
                 request.bankbookCopy(),
-                CompanyAddress.from(request.addressRegisterRequest())
+                CompanyAddress.register(request.addressRegisterRequest())
         );
     }
 

--- a/src/main/java/hanieum/conik/domain/company/entity/CompanyAddress.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/CompanyAddress.java
@@ -3,6 +3,7 @@ package hanieum.conik.domain.company.entity;
 import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,28 +12,46 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class CompanyAddress{
-    @Column(name = "address_postal_code", length = 20, nullable = false)
+    @Column(name = "postal_code", length = 20, nullable = false)
     private String postalCode;
-    @Column(name = "address_street_address", length = 255, nullable = false)
+
+    @Column(name = "street_address", length = 255, nullable = false)
     private String streetAddress;
-    @Column(name = "address_detail_address", length = 255)
+
+    @Column(name = "detail_address", length = 255)
     private String detailAddress;
 
-    private CompanyAddress(String postalCode, String streetAddress, String detailAddress){
+    @Column(name = "address_name", nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false, length = 50)
+    private String recipient;
+
+    @Column(name = "address_phone_number", nullable = false, length = 20)
+    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+    private String phoneNumber;
+
+    private CompanyAddress(String postalCode, String streetAddress, String detailAddress, String name, String recipient, String phoneNumber) {
         this.postalCode = postalCode;
         this.streetAddress = streetAddress;
         this.detailAddress = detailAddress;
+        this.name = name;
+        this.recipient = recipient;
+        this.phoneNumber = phoneNumber;
     }
 
     public static CompanyAddress register(AddressRegisterRequest req) {
         return new CompanyAddress(
                 req.postalCode(),
                 req.streetAddress(),
-                req.detailAddress()
+                req.detailAddress(),
+                req.addressName(),
+                req.recipient(),
+                req.phoneNumber()
         );
     }
 
     public static CompanyAddress from(AddressRegisterRequest dto) {
-        return new CompanyAddress(dto.postalCode(), dto.streetAddress(), dto.detailAddress());
+        return new CompanyAddress(dto.postalCode(), dto.streetAddress(), dto.detailAddress(), dto.addressName(), dto.recipient(), dto.phoneNumber());
     }
 }

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -54,6 +54,12 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberAddress> addresses = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY) // 기본 배송지 FK
+    @JoinColumn(name = "default_member_address_id")
+    private MemberAddress defaultAddress;
+
+    /* ========= 생성/팩토리 ========= */
+
     private Member(String name, Email email, String hashedPassword, String phoneNumber, Boolean termsOfServiceAgreed, MemberRole role, MemberAddress memberAddress) {
         if (!termsOfServiceAgreed) {
             throw new MemberException(MemberErrorType.TERMS_NOT_AGREED);
@@ -104,6 +110,8 @@ public class Member extends BaseEntity {
         return member;
     }
 
+    /* ========= 도메인 로직 ========= */
+
     /**
      * 비밀번호 검증
      * @param rawPassword
@@ -141,15 +149,39 @@ public class Member extends BaseEntity {
     public void addAddress(MemberAddress address) {
         addresses.add(address);
         address.setMember(this);
+
+        if (this.defaultAddress == null) {
+            this.defaultAddress = address;
+        }
+    }
+
+    /**
+     * 주소 추가 + 기본 배송지로 설정 여부까지 한 번에 처리 (체크박스용)
+     */
+    public MemberAddress addAddress(MemberAddress address, boolean setAsDefault) {
+        addAddress(address);
+        if (setAsDefault) {
+            setDefaultAddress(address);
+        }
+        return address;
     }
 
     /**
      * 회원 주소 삭제
      */
     public void deleteAddress(Long addressId) {
-        boolean removed = this.addresses.removeIf(address -> address.getId().equals(addressId));
-        if (!removed) {
-            throw new MemberException(MemberErrorType.ADDRESS_NOT_FOUND);
+        MemberAddress target = addresses.stream()
+                .filter(a -> a.getId().equals(addressId))
+                .findFirst()
+                .orElseThrow(() -> new MemberException(MemberErrorType.ADDRESS_NOT_FOUND));
+
+        boolean wasDefault = (defaultAddress != null && defaultAddress.equals(target));
+
+        addresses.remove(target);
+        target.setMember(null);
+
+        if (wasDefault) {
+            this.defaultAddress = addresses.isEmpty() ? null : addresses.get(0);
         }
     }
 
@@ -169,5 +201,20 @@ public class Member extends BaseEntity {
             throw new MemberException(MemberErrorType.INVALID_ROLE_FOR_COMPANY);
         }
         this.companyId = companyId;
+    }
+
+    /**
+     * 기본 배송지 변경(엔티티로)
+     * - 반드시 나의 주소여야 한다.
+     */
+    public void setDefaultAddress(MemberAddress address) {
+        if (address == null) {
+            this.defaultAddress = null;
+            return;
+        }
+        if (address.getMember() != this) {
+            throw new MemberException(MemberErrorType.ADDRESS_NOT_FOUND);
+        }
+        this.defaultAddress = address;
     }
 }

--- a/src/main/java/hanieum/conik/domain/member/MemberAddress.java
+++ b/src/main/java/hanieum/conik/domain/member/MemberAddress.java
@@ -2,6 +2,8 @@ package hanieum.conik.domain.member;
 
 import hanieum.conik.domain.common.address.AddressBase;
 import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
+import hanieum.conik.domain.common.address.exception.AddressErrorType;
+import hanieum.conik.domain.common.address.exception.AddressException;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
@@ -15,20 +17,41 @@ public class MemberAddress extends AddressBase {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    protected MemberAddress() { super(null,null,null); }
+    protected MemberAddress() { super(null,null,null,null,null,null); }
 
-    private MemberAddress(String postal, String street, String detail) {
-        super(postal, street, detail);
+    private MemberAddress(String postalCode, String streetAddress, String detailAddress, String addressName, String recipient, String phoneNumber) {
+        super(postalCode, streetAddress, detailAddress, addressName, recipient, phoneNumber);
     }
 
     /**
-     * 주소를 등록한다
+     * 주소 정보를 업데이트 한다.
      */
-    public static MemberAddress register(AddressRegisterRequest req) {
+    public static MemberAddress register(AddressRegisterRequest request) {
+        if (request.addressName() == null || request.addressName().isBlank()) {
+            throw new AddressException(AddressErrorType.INVALID_NAME);
+        }
+        if (request.recipient() == null || request.recipient().isBlank()) {
+            throw new AddressException(AddressErrorType.INVALID_RECIPIENT);
+        }
+        if (request.phoneNumber() == null || request.phoneNumber().isBlank()) {
+            throw new AddressException(AddressErrorType.INVALID_PHONE_NUMBER);
+        }
+        if (request.postalCode() == null || request.postalCode().isBlank()) {
+            throw new AddressException(AddressErrorType.INVALID_POSTAL_CODE);
+        }
+        if (request.streetAddress() == null || request.streetAddress().isBlank()) {
+            throw new AddressException(AddressErrorType.INVALID_STREET_ADDRESS);
+        }
+        if (request.detailAddress() == null || request.detailAddress().isBlank()) {
+            throw new AddressException(AddressErrorType.INVALID_DETAIL_ADDRESS);
+        }
         return new MemberAddress(
-                req.postalCode(),
-                req.streetAddress(),
-                req.detailAddress()
+                request.postalCode().trim(),
+                request.streetAddress().trim(),
+                request.detailAddress().trim(),
+                request.addressName().trim(),
+                request.recipient().trim(),
+                request.phoneNumber().trim()
         );
     }
 

--- a/src/main/java/hanieum/conik/domain/member/MemberAddress.java
+++ b/src/main/java/hanieum/conik/domain/member/MemberAddress.java
@@ -34,6 +34,9 @@ public class MemberAddress extends AddressBase {
             throw new AddressException(AddressErrorType.INVALID_RECIPIENT);
         }
         if (request.phoneNumber() == null || request.phoneNumber().isBlank()) {
+            if (!request.phoneNumber().matches("^010-\\d{4}-\\d{4}$")) {
+                throw new AddressException(AddressErrorType.INVALID_PHONE_NUMBER);
+            }
             throw new AddressException(AddressErrorType.INVALID_PHONE_NUMBER);
         }
         if (request.postalCode() == null || request.postalCode().isBlank()) {

--- a/src/main/java/hanieum/conik/domain/member/MemberAddress.java
+++ b/src/main/java/hanieum/conik/domain/member/MemberAddress.java
@@ -34,9 +34,9 @@ public class MemberAddress extends AddressBase {
             throw new AddressException(AddressErrorType.INVALID_RECIPIENT);
         }
         if (request.phoneNumber() == null || request.phoneNumber().isBlank()) {
-            if (!request.phoneNumber().matches("^010-\\d{4}-\\d{4}$")) {
-                throw new AddressException(AddressErrorType.INVALID_PHONE_NUMBER);
-            }
+            throw new AddressException(AddressErrorType.INVALID_PHONE_NUMBER);
+        }
+        if (!request.phoneNumber().trim().matches("^010-\\d{4}-\\d{4}$")) {
             throw new AddressException(AddressErrorType.INVALID_PHONE_NUMBER);
         }
         if (request.postalCode() == null || request.postalCode().isBlank()) {

--- a/src/main/java/hanieum/conik/global/adapter/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanieum/conik/global/adapter/security/jwt/JwtAuthenticationFilter.java
@@ -56,7 +56,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             if (token != null) {
                 Authentication auth = jwtTokenProviderPort.getAuthentication(token);
-                log.info("auth name={}, authorities={}", auth.getName(), auth.getAuthorities());
+                log.info("auth addressName={}, authorities={}", auth.getName(), auth.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(auth);
                 log.info("Authentication set in SecurityContext.");
             }

--- a/src/main/java/hanieum/conik/global/adapter/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hanieum/conik/global/adapter/security/jwt/JwtAuthenticationFilter.java
@@ -56,7 +56,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             if (token != null) {
                 Authentication auth = jwtTokenProviderPort.getAuthentication(token);
-                log.info("auth addressName={}, authorities={}", auth.getName(), auth.getAuthorities());
+                log.info("auth name={}, authorities={}", auth.getName(), auth.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(auth);
                 log.info("Authentication set in SecurityContext.");
             }

--- a/src/test/java/hanieum/conik/application/member/MemberFinderServiceTest.java
+++ b/src/test/java/hanieum/conik/application/member/MemberFinderServiceTest.java
@@ -1,11 +1,8 @@
 package hanieum.conik.application.member;
 
 import hanieum.conik.adapter.member.dto.MemberAddressResponse;
-import hanieum.conik.application.member.provided.MemberFinder;
-import hanieum.conik.application.member.required.MemberAddressRepository;
 import hanieum.conik.application.member.required.MemberRepository;
 import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
-import hanieum.conik.domain.common.email.Email;
 import hanieum.conik.domain.member.Member;
 import hanieum.conik.domain.member.MemberAddress;
 import hanieum.conik.domain.member.dto.MemberSignUpRequest;
@@ -37,30 +34,37 @@ class MemberFinderServiceTest {
     @Test
     @DisplayName("멤버 주소 목록 조회 - 성공")
     void findAddresses_success() {
-
-        var baseAddr = new AddressRegisterRequest("00000", "기본로", "0호");
+        var baseAddr = new AddressRegisterRequest("우리집", "홍길동", "010-4130-1951", "12345", "행복로", "101호", true);
         var signUpReq = new MemberSignUpRequest(
                 "홍길동", "hong@example.com", "raw-pw", "010-1234-5678",
                 true, baseAddr
         );
+
         Member member = Member.signUpIndividual(signUpReq);
 
         member.getAddresses().clear();
-        member.addAddress(MemberAddress.register(new AddressRegisterRequest("12345", "행복로", "101호")));
-        member.addAddress(MemberAddress.register(new AddressRegisterRequest("23456", "희망로", "202호")));
+        member.setDefaultAddress(null);
+
+        member.addAddress(MemberAddress.register(
+                new AddressRegisterRequest("우리집", "홍길동", "010-4130-1951","12345", "행복로", "101호", false)));
+        member.addAddress(MemberAddress.register(
+                new AddressRegisterRequest("우리집", "홍길동", "010-4130-1951","12345", "행복로", "102호", false)));
 
         memberRepository.saveAndFlush(member);
-        Long memberId = member.getId();
+
+        member.setDefaultAddress(member.getAddresses().get(0));
+        memberRepository.saveAndFlush(member);
 
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 
         // when
-        Page<MemberAddressResponse> page = memberFinder.findAddresses(memberId, pageable);
+        Page<MemberAddressResponse> page = memberFinder.findAddresses(member.getId(), pageable);
 
         // then
         assertThat(page.getTotalElements()).isEqualTo(2);
         assertThat(page.getContent()).hasSize(2);
     }
+
 
     @Test
     @DisplayName("멤버 주소 목록 조회 - 멤버 없음")

--- a/src/test/java/hanieum/conik/application/member/MemberModifyServiceTest.java
+++ b/src/test/java/hanieum/conik/application/member/MemberModifyServiceTest.java
@@ -103,7 +103,7 @@ class MemberModifyServiceTest {
         Member member = mock(Member.class);
         given(memberFinder.findById(memberId)).willReturn(member);
 
-        AddressRegisterRequest addressRequest = new AddressRegisterRequest("12345", "행복로", "101호");
+        AddressRegisterRequest addressRequest = new AddressRegisterRequest("우리집", "홍길동", "010-4130-1951","12345", "행복로", "101호", true);
         ArgumentCaptor<MemberAddress> addressCaptor = ArgumentCaptor.forClass(MemberAddress.class);
         //when
         memberModifyService.addAddress(memberId, addressRequest);

--- a/src/test/java/hanieum/conik/application/member/MemberModifyServiceTest.java
+++ b/src/test/java/hanieum/conik/application/member/MemberModifyServiceTest.java
@@ -98,24 +98,30 @@ class MemberModifyServiceTest {
     @Test
     @DisplayName("addAddress 성공")
     void addAddress_success() {
-        //given
+        // given
         long memberId = 1L;
         Member member = mock(Member.class);
         given(memberFinder.findById(memberId)).willReturn(member);
 
-        AddressRegisterRequest addressRequest = new AddressRegisterRequest("우리집", "홍길동", "010-4130-1951","12345", "행복로", "101호", true);
+        AddressRegisterRequest addressRequest =
+                new AddressRegisterRequest("우리집", "홍길동", "010-4130-1951","12345", "행복로", "101호", true);
+
         ArgumentCaptor<MemberAddress> addressCaptor = ArgumentCaptor.forClass(MemberAddress.class);
-        //when
+        ArgumentCaptor<Boolean> defaultFlagCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        // when
         memberModifyService.addAddress(memberId, addressRequest);
 
-        //then
-        then(member).should().addAddress(addressCaptor.capture());
-        MemberAddress capturedAddress = addressCaptor.getValue();
+        // then
+        then(member).should().addAddress(addressCaptor.capture(), defaultFlagCaptor.capture());
+        MemberAddress captured = addressCaptor.getValue();
 
-        assertEquals("12345", capturedAddress.getPostalCode());
-        assertEquals("행복로", capturedAddress.getStreetAddress());
-        assertEquals("101호", capturedAddress.getDetailAddress());
+        assertEquals("12345", captured.getPostalCode());
+        assertEquals("행복로", captured.getStreetAddress());
+        assertEquals("101호", captured.getDetailAddress());
+        assertTrue(defaultFlagCaptor.getValue());
     }
+
 
     @Test
     @DisplayName("deleteAddress 성공")

--- a/src/test/java/hanieum/conik/domain/favorite/FavoriteTest.java
+++ b/src/test/java/hanieum/conik/domain/favorite/FavoriteTest.java
@@ -1,6 +1,5 @@
 package hanieum.conik.domain.favorite;
 
-import hanieum.conik.domain.favorite.dto.FavoriteRequest;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## 💡 관련 이슈
- #88 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 주소에 배송지명, 수령인, 전화번호 입력/조회 지원
  - 주소 등록 시 기본 여부(default) 전송/처리 지원
  - 회원 정보 조회에 기본 배송지 포함 및 기본 배송지 지정/변경 기능 추가
- **개선**
  - 전화번호 형식 검증(예: 010-1234-5678) 및 관련 오류 메시지 추가
  - 회사 주소 필드 및 정렬 키 정비로 일관된 정렬/표시
- **테스트**
  - 기본/추가 주소 시나리오 및 확장된 주소 필드 검증 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->