### PR TITLE
FEAT: 소상공인 마이페이지 - 내 정보 탭 필수 API를 구현한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ out/
 /src/main/resources/application-test.yml
 /src/test/resources/application.yml
 /도메인모델.md
+
+### Mac OS
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -42,18 +42,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	//redis & DB
+	// redis & DB
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.session:spring-session-data-redis'
 	implementation 'org.postgresql:postgresql'
 
-	//swagger
+	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
-	//actuator
+	// actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	//Emailclient
+	// Emailclient
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
@@ -61,14 +61,14 @@ dependencies {
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
 
-	//feign Client
+	// feign Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.5'
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
-	//JWT
+	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
@@ -78,6 +78,9 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+
+	// CoolSms
+	implementation 'net.nurigo:sdk:4.3.0'
 }
 
 test {

--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
@@ -12,8 +12,8 @@ public record MemberInfoResponse(
         String name,
         String phoneNumber,
         boolean termsOfServiceAgreed,
-        boolean emailConsent,
-        boolean smsConsent,
+        boolean emailMarketingAgreed,
+        boolean smsMarketingAgreed,
         MemberRole memberType,
         List<MemberAddressResponse> addresses,
         MemberAddressResponse defaultAddress
@@ -25,8 +25,8 @@ public record MemberInfoResponse(
                 member.getName(),
                 member.getPhoneNumber(),
                 member.getTermsOfServiceAgreed(),
-                member.getEmailConsent(),
-                member.getSmsConsent(),
+                member.getEmailMarketingAgreed(),
+                member.getSmsMarketingAgreed(),
                 member.getRole(),
                 member.getAddresses().stream()
                         .map(MemberAddressResponse::from)

--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
@@ -2,7 +2,6 @@ package hanieum.conik.adapter.member.dto;
 
 import hanieum.conik.domain.common.email.Email;
 import hanieum.conik.domain.member.Member;
-import hanieum.conik.domain.member.MemberAddress;
 import hanieum.conik.domain.member.enumerate.MemberRole;
 
 import java.util.List;
@@ -13,6 +12,8 @@ public record MemberInfoResponse(
         String name,
         String phoneNumber,
         boolean termsOfServiceAgreed,
+        boolean emailConsent,
+        boolean smsConsent,
         MemberRole memberType,
         List<MemberAddressResponse> addresses,
         MemberAddressResponse defaultAddress
@@ -24,6 +25,8 @@ public record MemberInfoResponse(
                 member.getName(),
                 member.getPhoneNumber(),
                 member.getTermsOfServiceAgreed(),
+                member.getEmailConsent(),
+                member.getSmsConsent(),
                 member.getRole(),
                 member.getAddresses().stream()
                         .map(MemberAddressResponse::from)

--- a/src/main/java/hanieum/conik/adapter/member/sms/CoolSmsSender.java
+++ b/src/main/java/hanieum/conik/adapter/member/sms/CoolSmsSender.java
@@ -1,0 +1,81 @@
+package hanieum.conik.adapter.member.sms;
+
+import hanieum.conik.application.member.required.SmsSender;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("!test")
+public class CoolSmsSender implements SmsSender {
+
+    private final DefaultMessageService messageService;
+
+    public CoolSmsSender(
+            @Value("${coolsms.api-key}") String apiKey,
+            @Value("${coolsms.api-secret}") String apiSecret
+    ) {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, "https://api.coolsms.co.kr");
+    }
+
+    @Value("${coolsms.sender-number}")
+    private String sender;
+
+    /**
+     * 인증번호를 생성하는 메서드
+     * 6자리의 랜덤 숫자를 생성합니다.
+     *
+     * @return 생성된 인증번호
+     */
+    @Override
+    public int generateAuthNumber() {
+        return (int)(Math.random() * (90000)) + 100000;
+    }
+
+    /**
+     * 인증 문자를 전송하는 메서드
+     *
+     * @param phoneNumber 수신할 전화번호
+     * @return 생성된 인증번호
+     */
+    @Override
+    public int sendAuthSms(String phoneNumber) {
+        int authNumber = generateAuthNumber();
+
+        String message = "[CONIC] 인증번호 [" + authNumber + "]를 입력해주세요.";
+
+        sendSms(phoneNumber, message);
+
+        return authNumber;
+    }
+
+    /**
+     * 문자를 전송하는 메서드
+     *
+     * @param phoneNumber 수신할 전화번호
+     * @param message 발송할 내용
+     */
+    @Override
+    public void sendSms(String phoneNumber, String message) {
+        try {
+            String processed = message.replace("\\n", "\n");
+
+            Message msg = new Message();
+            msg.setFrom(sender);
+            msg.setTo(phoneNumber);
+            msg.setText(processed);
+
+            messageService.sendOne(new SingleMessageSendingRequest(msg));
+            log.info("SMS 전송 성공: {}", phoneNumber);
+        } catch (Exception e) {
+            log.error("SMS 전송 실패 ({}): {}", phoneNumber, e.getMessage());
+            throw new RuntimeException("SMS 전송에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/hanieum/conik/adapter/member/sms/PhoneVerificationAdapter.java
+++ b/src/main/java/hanieum/conik/adapter/member/sms/PhoneVerificationAdapter.java
@@ -1,0 +1,23 @@
+package hanieum.conik.adapter.member.sms;
+
+import hanieum.conik.application.member.required.PhoneVerificationStore;
+import hanieum.conik.global.application.required.MemoryMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhoneVerificationAdapter implements PhoneVerificationStore {
+    private final MemoryMap memoryMap;
+
+    @Override
+    public boolean isVerified(String phoneNumber) {
+        String verified = memoryMap.getValue("verified:" + phoneNumber);
+        return "true".equals(verified);
+    }
+
+    @Override
+    public void removeVerifiedFlag(String phoneNumber) {
+        memoryMap.deleteValue("verified:" + phoneNumber);
+    }
+}

--- a/src/main/java/hanieum/conik/adapter/member/sms/dto/SmsAuthCodeRequest.java
+++ b/src/main/java/hanieum/conik/adapter/member/sms/dto/SmsAuthCodeRequest.java
@@ -1,0 +1,12 @@
+package hanieum.conik.adapter.member.sms.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SmsAuthCodeRequest(
+        @NotBlank
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+        @Schema(description = "인증코드를 보낼 휴대폰 번호", example = "010-1234-5678")
+        String phoneNumber
+) {}

--- a/src/main/java/hanieum/conik/adapter/member/sms/dto/SmsCertificateRequest.java
+++ b/src/main/java/hanieum/conik/adapter/member/sms/dto/SmsCertificateRequest.java
@@ -1,0 +1,16 @@
+package hanieum.conik.adapter.member.sms.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SmsCertificateRequest(
+        @NotBlank
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+        @Schema(description = "인증코드를 보낼 휴대폰 번호", example = "010-1234-5678")
+        String phoneNumber,
+
+        @NotBlank
+        @Schema(description = "인증 코드", example = "123456")
+        String authCode
+){};

--- a/src/main/java/hanieum/conik/adapter/member/webapi/EmailController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/EmailController.java
@@ -20,14 +20,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class EmailController {
     private final EmailCertService emailCertService;
 
-    @Operation(summary = "인증번호 전송 API", description = "사용자에게 인증번호를 전송합니다.")
+    @Operation(summary = "이메일 인증번호 전송 API", description = "사용자에게 인증번호를 전송합니다.")
     @PostMapping()
     public ApiResponse<?> sendEmail(@RequestBody @Valid AuthCodeRequest authCodeRequest) {
         emailCertService.sendEmail(authCodeRequest);
         return ApiResponse.success("이메일 전송 성공");
     }
 
-    @Operation(summary = "인증번호 검증 API", description = "인증번호를 검증합니다.")
+    @Operation(summary = "이메일 인증번호 검증 API", description = "인증번호를 검증합니다.")
     @PostMapping("/certificate")
     public ApiResponse<?> sendEmailWithCertificate(@RequestBody @Valid CertificateRequest certificateRequest) {
         return ApiResponse.success(emailCertService.certificateEmail(certificateRequest));

--- a/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
@@ -6,8 +6,7 @@ import hanieum.conik.application.member.provided.MemberFinder;
 import hanieum.conik.application.member.provided.MemberSaver;
 import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
 import hanieum.conik.domain.member.Member;
-import hanieum.conik.domain.member.dto.MemberProfileUpdateRequest;
-import hanieum.conik.domain.member.dto.PasswordChangeRequest;
+import hanieum.conik.domain.member.dto.*;
 import hanieum.conik.global.adapter.security.AuthDetails;
 import hanieum.conik.global.apiPayload.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,7 +36,7 @@ public class MemberController {
     ## 회원 정보 수정을 수행합니다.
     - 사용자의 이름, 전화번호, 비밀번호, 이용약관 정보를 수정합니다.
     """)
-    @PatchMapping("/profile")
+    @PatchMapping("/profile") // TODO : 이거 공장 마이페이지 떄문에 만들었던 건가요?! UI가 이후에 수정된 거 같은데 안 쓰면 없애도 될 거 같아서용!
     public ApiResponse<?> updateMemberProfile(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestBody @Valid MemberProfileUpdateRequest request
@@ -47,9 +46,9 @@ public class MemberController {
     }
 
     @Operation(summary = "내 정보 조회", description = """
-            ## 내 정보를 조회합니다.
-            - 사용자의 기본 정보를 조회할 수 있습니다.
-            """)
+    ## 내 정보를 조회합니다.
+    - 사용자의 기본 정보를 조회할 수 있습니다.
+    """)
     @GetMapping("/me")
     public ApiResponse<MemberInfoResponse> getMemberInfo(
             @AuthenticationPrincipal AuthDetails authDetails
@@ -58,10 +57,75 @@ public class MemberController {
         return ApiResponse.success(MemberInfoResponse.from(member));
     }
 
+    @Operation(summary = "회원 정보 - 이름 수정", description = """
+    ## 회원 정보 - 이름 수정을 수행합니다.
+    - 사용자의 이름을 변경합니다.
+    """)
+    @PatchMapping("/me/name")
+    public ApiResponse<String> updateMemberName(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestBody @Valid MemberNameUpdateRequest request
+    ) {
+        memberSaver.updateName(authDetails.getMemberId(), request);
+        return ApiResponse.success("회원 이름 수정이 완료되었습니다.");
+    }
+
+    @Operation(summary = "회원 정보 - 비밀번호 수정", description = """
+    ## 회원 정보 - 비밀번호 수정을 수행합니다.
+    - 사용자의 비밀번호를 변경합니다.
+    """)
+    @PatchMapping("/me/password")
+    public ApiResponse<String> updateMemberPassword(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestBody @Valid MemberPasswordUpdateRequest request
+    ) {
+        memberSaver.updatePassword(authDetails.getMemberId(), request);
+        return ApiResponse.success("회원 비밀번호 수정이 완료되었습니다.");
+    }
+
+    @Operation(summary = "회원 정보 - 전화번호 수정", description = """
+    ## 회원 정보 - 전화번호 수정을 수행합니다.
+    - 사용자의 전화번호를 인증 후 변경합니다.
+    """)
+    @PatchMapping("/me/phone-number")
+    public ApiResponse<String> updateMemberPhoneNumber(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestBody @Valid MemberPhoneNumberUpdateRequest request
+    ) {
+        memberSaver.updatePhoneNumber(authDetails.getMemberId(), request);
+        return ApiResponse.success("회원 전화번호 수정이 완료되었습니다.");
+    }
+
+    @Operation(summary = "회원 정보 - 이메일 혜택/이벤트 정보 알림 수신 동의 여부 수정", description = """
+    ## 회원 정보 -  이메일 혜택/이벤트 정보 알림 수신 동의 여부 수정을 수행합니다.
+    - 사용자의 이메일 혜택/이벤트 정보 알림 수신 동의 여부를 수정합니다.
+    """)
+    @PatchMapping("/me/email-marketing-consent")
+    public ApiResponse<String> updateMemberEmailMarketingConsent(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestBody @Valid MemberEmailMarketingConsentUpdateRequest request
+    ) {
+        memberSaver.updateEmailMarketingConsent(authDetails.getMemberId(), request);
+        return ApiResponse.success("이메일 혜택/이벤트 정보 알림 수신 동의 여부 수정이 완료되었습니다.");
+    }
+
+    @Operation(summary = "회원 정보 - 전화번호 혜택/이벤트 정보 알림 수신 동의 여부 수정", description = """
+    ## 회원 정보 - 전화번호 혜택/이벤트 정보 알림 수신 동의 여부 수정을 수행합니다.
+    - 사용자의 전화번호 혜택/이벤트 정보 알림 수신 동의 여부를 수정합니다.
+    """)
+    @PatchMapping("/me/sms-marketing-consent")
+    public ApiResponse<String> updateMemberSmsMarketingConsent(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestBody @Valid MemberSmsMarketingConsentUpdateRequest request
+    ) {
+        memberSaver.updateSmsMarketingConsent(authDetails.getMemberId(), request);
+        return ApiResponse.success("전화번호 혜택/이벤트 정보 알림 수신 동의 여부 수정이 완료되었습니다.");
+    }
+
     @Operation(summary = "비밀번호 인증하기", description = """
-            ## 입력한 비밀번호가 현재 비밀번호와 일치하는지 확인합니다.
-            - 사용자가 현재 비밀번호를 인증할 수 있습니다.
-            """)
+    ## 입력한 비밀번호가 현재 비밀번호와 일치하는지 확인합니다.
+    - 사용자가 현재 비밀번호를 인증할 수 있습니다.
+    """)
     @PostMapping("/password")
     public ApiResponse<?> certificatePassword(
             @AuthenticationPrincipal AuthDetails authDetails,

--- a/src/main/java/hanieum/conik/adapter/member/webapi/SmsController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/SmsController.java
@@ -1,0 +1,35 @@
+package hanieum.conik.adapter.member.webapi;
+
+import hanieum.conik.adapter.member.sms.dto.SmsAuthCodeRequest;
+import hanieum.conik.adapter.member.sms.dto.SmsCertificateRequest;
+import hanieum.conik.application.member.SmsCertService;
+import hanieum.conik.global.apiPayload.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/sms")
+@Tag(name = "USER", description = "사용자 도메인 API")
+public class SmsController {
+    private final SmsCertService smsCertService;
+
+    @Operation(summary = "휴대폰 인증번호 전송 API", description = "사용자에게 인증번호를 전송합니다.")
+    @PostMapping()
+    public ApiResponse<?> sendSms(@RequestBody @Valid SmsAuthCodeRequest authCodeRequest) {
+        smsCertService.sendSms(authCodeRequest);
+        return ApiResponse.success("문자 전송 성공");
+    }
+
+    @Operation(summary = "휴대폰 인증번호 검증 API", description = "인증번호를 검증합니다.")
+    @PostMapping("/certificate")
+    public ApiResponse<?> sendSmsWithCertificate(@RequestBody @Valid SmsCertificateRequest certificateRequest) {
+        return ApiResponse.success(smsCertService.certificatePhoneNumber(certificateRequest));
+    }
+}

--- a/src/main/java/hanieum/conik/application/member/EmailCertService.java
+++ b/src/main/java/hanieum/conik/application/member/EmailCertService.java
@@ -23,7 +23,7 @@ public class EmailCertService{
     private static final long OTP_TIMEOUT = 5 * 60_000L; // 5분
 
     public void sendEmail(AuthCodeRequest authCodeRequest) {
-        auth.checkDuplicateEmail(EmailAvailabilityRequest.from(authCodeRequest.email()));
+        auth.checkDuplicateEmail(EmailAvailabilityRequest.from(authCodeRequest.email())); // TODO: 여기서 checkDuplicateEmail을 하는 이유가 뭔가요? 이미 존재하는 사용자는 이메일 인증을 할 수 없는 이유는..?
 
         int authNumber = emailSender.sendAuthMail(authCodeRequest.email());
         memoryMap.setValue(authCodeRequest.email(), String.valueOf(authNumber), OTP_TIMEOUT);

--- a/src/main/java/hanieum/conik/application/member/MemberModifyService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberModifyService.java
@@ -5,7 +5,7 @@ import hanieum.conik.application.member.provided.MemberSaver;
 import hanieum.conik.domain.member.MemberAddress;
 import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
 import hanieum.conik.domain.member.Member;
-import hanieum.conik.domain.member.dto.MemberProfileUpdateRequest;
+import hanieum.conik.domain.member.dto.*;
 import hanieum.conik.domain.member.exception.MemberErrorType;
 import hanieum.conik.domain.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +47,44 @@ public class MemberModifyService implements MemberSaver {
         if (request.newPhoneNumber() != null && !request.newPhoneNumber().isBlank()) {
             member.updatePhoneNumber(request.newPhoneNumber().trim());
         }
+    }
+
+    @Override
+    public void updateName(Long memberId, MemberNameUpdateRequest request) {
+        Member member = memberFinder.findById(memberId);
+
+        member.updateName(request.name().trim());
+    }
+
+    @Override
+    public void updatePassword(Long memberId, MemberPasswordUpdateRequest request) {
+        Member member = memberFinder.findById(memberId);
+
+        validateCurrentPassword(memberId, request.currentPassword());
+        member.updatePassword(passwordEncoder.encode(request.newPassword()));
+    }
+
+    @Override
+    public void updatePhoneNumber(Long memberId, MemberPhoneNumberUpdateRequest request) {
+        Member member = memberFinder.findById(memberId);
+
+        // TODO : 전화번호 인증 로직 추가
+
+        member.updatePhoneNumber(request.newPhoneNumber().trim());
+    }
+
+    @Override
+    public void updateEmailMarketingConsent(Long memberId, MemberEmailMarketingConsentUpdateRequest request) {
+        Member member = memberFinder.findById(memberId);
+
+        member.updateEmailMarketingAgreed(request.isEmailMarketingAgreed());
+    }
+
+    @Override
+    public void updateSmsMarketingConsent(Long memberId, MemberSmsMarketingConsentUpdateRequest request) {
+        Member member = memberFinder.findById(memberId);
+
+        member.updateSmsMarketingAgreed(request.isSmsMarketingAgreed());
     }
 
     @Override

--- a/src/main/java/hanieum/conik/application/member/MemberModifyService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberModifyService.java
@@ -30,11 +30,13 @@ public class MemberModifyService implements MemberSaver {
     public void updateProfile(Long memberId, MemberProfileUpdateRequest request) {
         Member member = memberFinder.findById(memberId);
 
-        if (StringUtils.isNotBlank(request.currentPassword()) || StringUtils.isNotBlank(request.newPassword())) {
-            if (StringUtils.isBlank(request.currentPassword()) || StringUtils.isBlank(request.newPassword())) {
-                throw new MemberException(MemberErrorType.INVALID_PASSWORD_UPDATE_REQUEST);
-            }
+        boolean hasCurrentPassword = StringUtils.isNotBlank(request.currentPassword());
+        boolean hasNewPassword = StringUtils.isNotBlank(request.newPassword());
 
+        if (hasCurrentPassword != hasNewPassword) {
+            throw new MemberException(MemberErrorType.INVALID_PASSWORD_UPDATE_REQUEST);
+        }
+        if (hasNewPassword) {
             validateCurrentPassword(memberId, request.currentPassword());
             member.updatePassword(passwordEncoder.encode(request.newPassword()));
         }

--- a/src/main/java/hanieum/conik/application/member/MemberModifyService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberModifyService.java
@@ -2,6 +2,7 @@ package hanieum.conik.application.member;
 
 import hanieum.conik.application.member.provided.MemberFinder;
 import hanieum.conik.application.member.provided.MemberSaver;
+import hanieum.conik.application.member.required.PhoneVerificationStore;
 import hanieum.conik.domain.member.MemberAddress;
 import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
 import hanieum.conik.domain.member.Member;
@@ -25,6 +26,7 @@ public class MemberModifyService implements MemberSaver {
 
     private final MemberFinder memberFinder;
     private final PasswordEncoder passwordEncoder;
+    private final PhoneVerificationStore phoneVerificationStore;
 
     @Override
     public void updateProfile(Long memberId, MemberProfileUpdateRequest request) {
@@ -67,10 +69,15 @@ public class MemberModifyService implements MemberSaver {
     @Override
     public void updatePhoneNumber(Long memberId, MemberPhoneNumberUpdateRequest request) {
         Member member = memberFinder.findById(memberId);
+        String newPhoneNumber = request.newPhoneNumber().trim();
 
-        // TODO : 전화번호 인증 로직 추가
+        if (!phoneVerificationStore.isVerified(newPhoneNumber)) {
+            throw new MemberException(MemberErrorType.INVALID_PHONE_NUMBER);
+        }
 
-        member.updatePhoneNumber(request.newPhoneNumber().trim());
+        member.updatePhoneNumber(newPhoneNumber);
+
+        phoneVerificationStore.removeVerifiedFlag(newPhoneNumber);
     }
 
     @Override

--- a/src/main/java/hanieum/conik/application/member/MemberModifyService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberModifyService.java
@@ -10,6 +10,7 @@ import hanieum.conik.domain.member.exception.MemberErrorType;
 import hanieum.conik.domain.member.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +30,12 @@ public class MemberModifyService implements MemberSaver {
     public void updateProfile(Long memberId, MemberProfileUpdateRequest request) {
         Member member = memberFinder.findById(memberId);
 
-        if(request.newPassword() != null && !request.newPassword().isBlank()) {
+        if (StringUtils.isNotBlank(request.currentPassword()) || StringUtils.isNotBlank(request.newPassword())) {
+            if (StringUtils.isBlank(request.currentPassword()) || StringUtils.isBlank(request.newPassword())) {
+                throw new MemberException(MemberErrorType.INVALID_PASSWORD_UPDATE_REQUEST);
+            }
+
+            validateCurrentPassword(memberId, request.currentPassword());
             member.updatePassword(passwordEncoder.encode(request.newPassword()));
         }
 

--- a/src/main/java/hanieum/conik/application/member/SmsCertService.java
+++ b/src/main/java/hanieum/conik/application/member/SmsCertService.java
@@ -24,13 +24,22 @@ public class SmsCertService {
         memoryMap.setValue(authCodeRequest.phoneNumber(), String.valueOf(authNumber), OTP_TIMEOUT);
     }
 
+    // TODO : 논의 후 Sms,EmailCertService에서 MemoryMap 직접 접근 -> VerificationStore 포트로 추상화 (현재 PhoneVerificationStore만 존재)
     public Boolean certificatePhoneNumber(SmsCertificateRequest certificateRequest) {
-        if (memoryMap.getValue(certificateRequest.phoneNumber()).equals(certificateRequest.authCode())) {
-            memoryMap.deleteValue(certificateRequest.phoneNumber());
-            return true;
+        String phoneNumber = certificateRequest.phoneNumber();
+        String inputCode = certificateRequest.authCode();
+
+        String storedCode = memoryMap.getValue(phoneNumber);
+        if (storedCode == null) {
+            throw new MemberException(MemberErrorType.EXPIRED_VERIFICATION_CODE);
         }
-        else{
+        if (!storedCode.equals(inputCode)) {
             throw new MemberException(MemberErrorType.INVALID_AUTHORIZATION_CODE);
         }
+
+        memoryMap.setValue("verified:" + phoneNumber, "true", OTP_TIMEOUT);
+        memoryMap.deleteValue(phoneNumber);
+
+        return true;
     }
 }

--- a/src/main/java/hanieum/conik/application/member/SmsCertService.java
+++ b/src/main/java/hanieum/conik/application/member/SmsCertService.java
@@ -1,0 +1,36 @@
+package hanieum.conik.application.member;
+
+import hanieum.conik.adapter.member.sms.dto.SmsAuthCodeRequest;
+import hanieum.conik.adapter.member.sms.dto.SmsCertificateRequest;
+import hanieum.conik.application.member.required.SmsSender;
+import hanieum.conik.domain.member.exception.MemberErrorType;
+import hanieum.conik.domain.member.exception.MemberException;
+import hanieum.conik.global.application.required.MemoryMap;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SmsCertService {
+    private final SmsSender smsSender;
+    private final MemoryMap memoryMap;
+
+    private static final long OTP_TIMEOUT = 5 * 60_000L; // 5분
+
+    public void sendSms(SmsAuthCodeRequest authCodeRequest) {
+        int authNumber = smsSender.sendAuthSms(authCodeRequest.phoneNumber());
+        memoryMap.setValue(authCodeRequest.phoneNumber(), String.valueOf(authNumber), OTP_TIMEOUT);
+    }
+
+    public Boolean certificatePhoneNumber(SmsCertificateRequest certificateRequest) {
+        if (memoryMap.getValue(certificateRequest.phoneNumber()).equals(certificateRequest.authCode())) {
+            memoryMap.deleteValue(certificateRequest.phoneNumber());
+            return true;
+        }
+        else{
+            throw new MemberException(MemberErrorType.INVALID_AUTHORIZATION_CODE);
+        }
+    }
+}

--- a/src/main/java/hanieum/conik/application/member/provided/MemberSaver.java
+++ b/src/main/java/hanieum/conik/application/member/provided/MemberSaver.java
@@ -1,7 +1,7 @@
 package hanieum.conik.application.member.provided;
 
 import hanieum.conik.domain.common.address.dto.AddressRegisterRequest;
-import hanieum.conik.domain.member.dto.MemberProfileUpdateRequest;
+import hanieum.conik.domain.member.dto.*;
 
 /**
  * 회원정보 변경/저장을 담당하는 포트 인터페이스
@@ -14,6 +14,16 @@ public interface MemberSaver {
      * @param updateReq   수정할 필드를 담은 DTO
      */
     void updateProfile(Long memberId, MemberProfileUpdateRequest updateReq);
+
+    void updateName(Long memberId, MemberNameUpdateRequest request);
+
+    void updatePassword(Long memberId, MemberPasswordUpdateRequest request);
+
+    void updatePhoneNumber(Long memberId, MemberPhoneNumberUpdateRequest request);
+
+    void updateEmailMarketingConsent(Long memberId, MemberEmailMarketingConsentUpdateRequest request);
+
+    void updateSmsMarketingConsent(Long memberId, MemberSmsMarketingConsentUpdateRequest request);
 
     void validateCurrentPassword(Long memberId, String currentPassword);
 

--- a/src/main/java/hanieum/conik/application/member/required/PhoneVerificationStore.java
+++ b/src/main/java/hanieum/conik/application/member/required/PhoneVerificationStore.java
@@ -1,0 +1,6 @@
+package hanieum.conik.application.member.required;
+
+public interface PhoneVerificationStore {
+    boolean isVerified(String phoneNumber);
+    void removeVerifiedFlag(String phoneNumber);
+}

--- a/src/main/java/hanieum/conik/application/member/required/SmsSender.java
+++ b/src/main/java/hanieum/conik/application/member/required/SmsSender.java
@@ -1,0 +1,29 @@
+package hanieum.conik.application.member.required;
+
+public interface SmsSender {
+
+    /**
+     * 인증번호를 생성하는 메서드
+     * 6자리의 랜덤 숫자를 생성합니다.
+     *
+     * @return 생성된 인증번호
+     */
+    int generateAuthNumber();
+
+    /**
+     * 인증 문자를 전송하는 메서드
+     *
+     * @param phoneNumber 수신할 전화번호
+     * @return 생성된 인증번호
+     */
+    int sendAuthSms(String phoneNumber);
+
+    /**
+     * 문자를 전송하는 메서드
+     *
+     * @param phoneNumber 수신할 전화번호
+     * @param content 발송할 내용
+     */
+    void sendSms(String phoneNumber, String content);
+
+}

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -44,6 +44,13 @@ public class Member extends BaseEntity {
     @Column(name = "terms_of_service_agreed", nullable = false)
     private Boolean termsOfServiceAgreed;
 
+    // TODO : k8s 연결 후 RDS 기본 값 설정, 이후 nullable = false로 변경
+    @Column(name = "email_consent", nullable = true)
+    private Boolean emailConsent;
+
+    @Column(name = "sms_consent", nullable = true)
+    private Boolean smsConsent;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = 20)
     private MemberRole role;
@@ -69,6 +76,8 @@ public class Member extends BaseEntity {
         this.hashedPassword = hashedPassword;
         this.phoneNumber = phoneNumber;
         this.termsOfServiceAgreed = termsOfServiceAgreed;
+        this.emailConsent = true;
+        this.smsConsent = true;
         this.role = role;
         if (memberAddress != null) {
             addAddress(memberAddress);

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -152,6 +152,20 @@ public class Member extends BaseEntity {
     }
 
     /**
+     * 이메일 마케팅 수신동의 여부 수정
+     */
+    public void updateEmailMarketingAgreed(boolean emailMarketingAgreed) {
+        this.emailMarketingAgreed = emailMarketingAgreed;
+    }
+
+    /**
+     * 전화번호 마케팅 수신동의 여부 수정
+     */
+    public void updateSmsMarketingAgreed(boolean smsMarketingAgreed) {
+        this.smsMarketingAgreed = smsMarketingAgreed;
+    }
+
+    /**
      * 회원 주소 추가
      */
     public void addAddress(MemberAddress address) {

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -1,12 +1,11 @@
 package hanieum.conik.domain.member;
 
-import hanieum.conik.domain.member.dto.MemberProfileUpdateRequest;
-import hanieum.conik.domain.member.dto.MemberSignUpRequest;
 import hanieum.conik.adapter.member.persistence.EmailAttributeConverter;
+import hanieum.conik.domain.common.email.Email;
+import hanieum.conik.domain.member.dto.MemberSignUpRequest;
 import hanieum.conik.domain.member.enumerate.MemberRole;
 import hanieum.conik.domain.member.exception.MemberErrorType;
 import hanieum.conik.domain.member.exception.MemberException;
-import hanieum.conik.domain.common.email.Email;
 import hanieum.conik.global.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -45,11 +44,11 @@ public class Member extends BaseEntity {
     private Boolean termsOfServiceAgreed;
 
     // TODO : k8s 연결 후 RDS 기본 값 설정, 이후 nullable = false로 변경
-    @Column(name = "email_consent", nullable = true)
-    private Boolean emailConsent;
+    @Column(name = "email_marketing_agreed", nullable = true)
+    private Boolean emailMarketingAgreed;
 
-    @Column(name = "sms_consent", nullable = true)
-    private Boolean smsConsent;
+    @Column(name = "sms_marketing_agreed", nullable = true)
+    private Boolean smsMarketingAgreed;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = 20)
@@ -76,8 +75,8 @@ public class Member extends BaseEntity {
         this.hashedPassword = hashedPassword;
         this.phoneNumber = phoneNumber;
         this.termsOfServiceAgreed = termsOfServiceAgreed;
-        this.emailConsent = false;
-        this.smsConsent = false;
+        this.emailMarketingAgreed = false;
+        this.smsMarketingAgreed = false;
         this.role = role;
         if (memberAddress != null) {
             addAddress(memberAddress);

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -76,8 +76,8 @@ public class Member extends BaseEntity {
         this.hashedPassword = hashedPassword;
         this.phoneNumber = phoneNumber;
         this.termsOfServiceAgreed = termsOfServiceAgreed;
-        this.emailConsent = true;
-        this.smsConsent = true;
+        this.emailConsent = false;
+        this.smsConsent = false;
         this.role = role;
         if (memberAddress != null) {
             addAddress(memberAddress);

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberEmailMarketingConsentUpdateRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberEmailMarketingConsentUpdateRequest.java
@@ -1,0 +1,10 @@
+package hanieum.conik.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberEmailMarketingConsentUpdateRequest(
+        @NotNull(message = "이메일 마케팅 수신동의 여부는 필수입니다.")
+        @Schema(description = "이메일 마케팅 수신동의 여부", example = "true")
+        Boolean isEmailMarketingAgreed
+) {}

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberNameUpdateRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberNameUpdateRequest.java
@@ -1,0 +1,12 @@
+package hanieum.conik.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MemberNameUpdateRequest(
+        @NotBlank(message = "이름은 빈 값이거나 null 일 수 없습니다.")
+        @Schema(description = "이름", example = "부승관")
+        @Size(min = 1, max = 20, message = "이름은 1자 이상 20자 이하여야 합니다.")
+        String name
+) {}

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberPasswordUpdateRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberPasswordUpdateRequest.java
@@ -1,0 +1,19 @@
+package hanieum.conik.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record MemberPasswordUpdateRequest (
+        @NotBlank(message = "기존 비밀번호는 빈 값이거나 null 일 수 없습니다.")
+        @Schema(description = "현재 비밀번호", example = "day6")
+        String currentPassword,
+
+        @NotBlank(message = "새로운 비밀번호는 빈 값이거나 null 일 수 없습니다.")
+        @Schema(description = "새 비밀번호", example = "seventeen17!")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+|\\-=\\[\\]{};:',.<>/?])[A-Za-z\\d!@#$%^&*()_+|\\-=\\[\\]{};:',.<>/?]{8,20}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8~20자여야 합니다."
+        )
+        String newPassword
+) {}

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberPhoneNumberUpdateRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberPhoneNumberUpdateRequest.java
@@ -1,0 +1,12 @@
+package hanieum.conik.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record MemberPhoneNumberUpdateRequest(
+        @NotBlank(message = "전화번호는 빈 값이거나 null 일 수 없습니다.")
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
+        String newPhoneNumber
+) {}

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberProfileUpdateRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberProfileUpdateRequest.java
@@ -13,6 +13,13 @@ public record MemberProfileUpdateRequest(
         @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
         String newPhoneNumber,
 
-        @Schema(description = "새 비밀번호", example = "day6")
+        @Schema(description = "현재 비밀번호", example = "day6")
+        String currentPassword,
+
+        @Schema(description = "새 비밀번호", example = "seventeen17!")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+|\\-=\\[\\]{};:',.<>/?])[A-Za-z\\d!@#$%^&*()_+|\\-=\\[\\]{};:',.<>/?]{8,20}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8~20자여야 합니다."
+        )
         String newPassword
 ){}

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberSignUpRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberSignUpRequest.java
@@ -18,6 +18,10 @@ public record MemberSignUpRequest(
         String email,
 
         @Schema(description = "비밀번호", example = "7897")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+|\\-=\\[\\]{};:',.<>/?])[A-Za-z\\d!@#$%^&*()_+|\\-=\\[\\]{};:',.<>/?]{8,20}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함하여 8~20자여야 합니다."
+        )
         @NotBlank(message = "비밀번호는 필수입니다.")
         String password,
 

--- a/src/main/java/hanieum/conik/domain/member/dto/MemberSmsMarketingConsentUpdateRequest.java
+++ b/src/main/java/hanieum/conik/domain/member/dto/MemberSmsMarketingConsentUpdateRequest.java
@@ -1,0 +1,10 @@
+package hanieum.conik.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record MemberSmsMarketingConsentUpdateRequest(
+        @NotNull(message = "전화번호 마케팅 수신동의 여부는 필수입니다.")
+        @Schema(description = "전화번호 마케팅 수신동의 여부", example = "true")
+        Boolean isSmsMarketingAgreed
+) {}

--- a/src/main/java/hanieum/conik/domain/member/exception/MemberErrorType.java
+++ b/src/main/java/hanieum/conik/domain/member/exception/MemberErrorType.java
@@ -20,9 +20,9 @@ public enum MemberErrorType implements ErrorType {
     INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "유효하지 않은 전화번호입니다."),
     INVALID_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 이름입니다."),
     COMPANY_ID_MISSING(HttpStatus.UNPROCESSABLE_ENTITY, "기업 회원의 companyId가 누락되었습니다."),
-    INVALID_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "유효하지 않은 이메일 인증 코드입니다."),
-    EXPIRED_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "이메일 인증 코드가 만료되었습니다."),
-    INVALID_PASSWORD_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "올바르지 않은 비밀번호 수정 요청입니다.")
+    INVALID_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "유효하지 않은 인증 코드입니다."),
+    EXPIRED_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "인증 코드가 만료되었습니다."),
+    INVALID_PASSWORD_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "올바르지 않은 비밀번호 수정 요청입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/hanieum/conik/domain/member/exception/MemberErrorType.java
+++ b/src/main/java/hanieum/conik/domain/member/exception/MemberErrorType.java
@@ -21,7 +21,8 @@ public enum MemberErrorType implements ErrorType {
     INVALID_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 이름입니다."),
     COMPANY_ID_MISSING(HttpStatus.UNPROCESSABLE_ENTITY, "기업 회원의 companyId가 누락되었습니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "유효하지 않은 이메일 인증 코드입니다."),
-    EXPIRED_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "이메일 인증 코드가 만료되었습니다.")
+    EXPIRED_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "이메일 인증 코드가 만료되었습니다."),
+    INVALID_PASSWORD_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "올바르지 않은 비밀번호 수정 요청입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/hanieum/conik/global/apiPayload/ApiControllerAdvice.java
+++ b/src/main/java/hanieum/conik/global/apiPayload/ApiControllerAdvice.java
@@ -38,6 +38,8 @@ public class ApiControllerAdvice {
 
             if (fieldError.getDefaultMessage() != null) {
                 message = fieldError.getDefaultMessage();
+            } else {
+                message = type.getMessage();
             }
         }
 

--- a/src/main/java/hanieum/conik/global/apiPayload/ApiControllerAdvice.java
+++ b/src/main/java/hanieum/conik/global/apiPayload/ApiControllerAdvice.java
@@ -30,13 +30,18 @@ public class ApiControllerAdvice {
                 .orElse(null);
 
         GlobalErrorType type = GlobalErrorType.FAILED_REQUEST_VALIDATION;
+        String message = type.getMessage();
 
         if (fieldError != null) {
             String key = fieldError.getField() + ":" + fieldError.getCode();
             type = VALIDATION_MAP.getOrDefault(key, GlobalErrorType.FAILED_REQUEST_VALIDATION);
+
+            if (fieldError.getDefaultMessage() != null) {
+                message = fieldError.getDefaultMessage();
+            }
         }
 
-        return new ResponseEntity<>(ApiResponse.error(type), type.getStatus());
+        return new ResponseEntity<>(ApiResponse.error(type, message), type.getStatus());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/hanieum/conik/global/apiPayload/exception/ErrorMessage.java
+++ b/src/main/java/hanieum/conik/global/apiPayload/exception/ErrorMessage.java
@@ -14,4 +14,8 @@ public class ErrorMessage {
         this.message = errorType.getMessage();
     }
 
+    public ErrorMessage(ErrorType errorType, String customMessage) {
+        this.code = errorType.name();
+        this.message = customMessage != null ? customMessage : errorType.getMessage();
+    }
 }

--- a/src/main/java/hanieum/conik/global/apiPayload/response/ApiResponse.java
+++ b/src/main/java/hanieum/conik/global/apiPayload/response/ApiResponse.java
@@ -17,4 +17,7 @@ public record ApiResponse<T>(ResultType result, T data, ErrorMessage error) {
         return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error));
     }
 
+    public static ApiResponse<?> error(ErrorType type, String customMessage) {
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(type, customMessage));
+    }
 }


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #92 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요

- `/v1/member/me`-> 에서 이메일/전화번호 수신동의 여부 추가
- 회원가입 시 비밀번호 검증 영어, 숫자, 특수문자 포함 8-20자로 조건 걸음
- 이름 변경 api 구현
- 비밀번호 변경 api 구현
- 이메일/문자 마케팅 수신동의 여부 변경 api 구현
- 전화번호 변경 api 구현 (휴대폰 인증 완료 시에 가능하도록)
- 전화 번호 인증 번호 전송 / 인증 api 구현

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

~~내 정보 탭에서는 기존 꺼 수정 정도 하면 됐어서 기존 코드 문제 없는지 한 번씩 확인 부탁드려욤
(혜택/정보 성 이메일, 전화번호 알림 전송은 언제 어떤거 보낼지 정해지면 구현할게용)
PR 작게작게 탭 별로 하나씩 올릴게요 ,, 🧎🏻‍♂️🧎🏻‍♂️~~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 회원 정보 응답에 이메일/문자 수신 동의(emailMarketingAgreed, smsMarketingAgreed) 추가.
  - 마이페이지에 이름/비밀번호/전화번호/이메일·문자 마케팅 수신 동의 개별 업데이트 엔드포인트 추가.
  - SMS 인증: 문자 전송/검증 API와 인증 서비스, SMS 발송 구현(CoolSMS 연동) 및 전화번호 검증 저장소/어댑터 추가.
  - 관련 DTO(이름/비밀번호/전화번호/마케팅 동의, SMS 요청/검증) 추가.
- 버그 수정 / 개선
  - 프로필 비밀번호 변경 검증 강화(현재/새 비밀번호 검증 및 명확한 오류).
  - 가입·비밀번호에 8–20자 영문·숫자·특수문자 패턴 검증 적용.
  - 유효성 검사 시 필드별 맞춤 메시지 및 커스텀 오류 메시지 지원 추가.
- 작업
  - .gitignore에 Mac OS(.DS_Store) 항목 추가.
  - SMS 라이브러리 의존성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->