### PR TITLE
FEAT: 소상공인 마이페이지 - 배송 정보 탭 필수 API를 구현한다.

### DIFF
--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberAddressResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberAddressResponse.java
@@ -1,5 +1,6 @@
 package hanieum.conik.adapter.member.dto;
 
+import hanieum.conik.domain.member.Member;
 import hanieum.conik.domain.member.MemberAddress;
 
 public record MemberAddressResponse(
@@ -9,7 +10,8 @@ public record MemberAddressResponse(
         String detailAddress,
         String addressName,
         String recipient,
-        String phoneNumber
+        String phoneNumber,
+        boolean isDefault
 ) {
     public static MemberAddressResponse from(MemberAddress address) {
         return new MemberAddressResponse(
@@ -19,7 +21,24 @@ public record MemberAddressResponse(
                 address.getDetailAddress(),
                 address.getAddressName(),
                 address.getRecipient(),
-                address.getPhoneNumber()
+                address.getPhoneNumber(),
+                false // TODO: 기존 코드와의 호환성으로 디폴트 false로 반환 - 논의 필요
+        );
+    }
+
+    public static MemberAddressResponse from(MemberAddress address, Member member) {
+        boolean isDefault = member.getDefaultAddress() != null
+                && member.getDefaultAddress().equals(address);
+
+        return new MemberAddressResponse(
+                address.getId(),
+                address.getPostalCode(),
+                address.getStreetAddress(),
+                address.getDetailAddress(),
+                address.getAddressName(),
+                address.getRecipient(),
+                address.getPhoneNumber(),
+                isDefault
         );
     }
 }

--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
@@ -2,7 +2,6 @@ package hanieum.conik.adapter.member.dto;
 
 import hanieum.conik.domain.common.email.Email;
 import hanieum.conik.domain.member.Member;
-import hanieum.conik.domain.member.MemberAddress;
 import hanieum.conik.domain.member.enumerate.MemberRole;
 
 import java.util.List;

--- a/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
@@ -88,7 +88,7 @@ public class MemberController {
     - 사용자가 등록한 주소 중, 특정 주소를 조회할 수 있습니다.
     """)
     @GetMapping("/me/addresses/{addressId}")
-    public ApiResponse<MemberAddressResponse> getMyAddresses(
+    public ApiResponse<MemberAddressResponse> getMyAddress(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long addressId
     ) {
@@ -113,7 +113,7 @@ public class MemberController {
     - 사용자가 입력한 주소를 수정할 수 있습니다.
     """)
     @PutMapping("/addresses/{addressId}")
-    public ApiResponse<?> addAddress(
+    public ApiResponse<?> updateAddress(
             @AuthenticationPrincipal AuthDetails authDetails,
             @PathVariable Long addressId,
             @RequestBody @Valid AddressRegisterRequest request

--- a/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
@@ -99,7 +99,7 @@ public class MemberController {
     ## 주소 추가를 수행합니다.
     - 사용자가 주소를 추가할 수 있습니다.
     """)
-    @PatchMapping("/addresses") // TODO: address 추가인데 왜 Post말고 Patch로 썼는지 궁금합니당 주소 수정 안되는 거 같던데..!
+    @PostMapping("/addresses")
     public ApiResponse<?> addAddress(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestBody @Valid AddressRegisterRequest request

--- a/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
@@ -87,13 +87,27 @@ public class MemberController {
     ## 주소 추가를 수행합니다.
     - 사용자가 주소를 추가할 수 있습니다.
     """)
-    @PatchMapping("/addresses")
+    @PatchMapping("/addresses") // TODO: address 추가인데 왜 Post말고 Patch로 썼는지 궁금합니당 주소 수정 안되는 거 같던데..!
     public ApiResponse<?> addAddress(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestBody @Valid AddressRegisterRequest request
     ) {
         memberSaver.addAddress(authDetails.getMemberId(), request);
         return ApiResponse.success("주소 추가가 완료되었습니다.");
+    }
+
+    @Operation(summary = "주소 수정", description = """
+    ## 주소를 업데이트합니다.
+    - 사용자가 입력한 주소를 수정할 수 있습니다.
+    """)
+    @PutMapping("/addresses/{addressId}")
+    public ApiResponse<?> addAddress(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long addressId,
+            @RequestBody @Valid AddressRegisterRequest request
+    ) {
+        memberSaver.updateAddress(authDetails.getMemberId(), addressId, request);
+        return ApiResponse.success("주소 수정이 완료되었습니다.");
     }
 
     @Operation(summary = "주소 삭제", description = """

--- a/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
@@ -83,6 +83,18 @@ public class MemberController {
         return ApiResponse.success(memberFinder.findAddresses(authDetails.getMemberId(), pageable));
     }
 
+    @Operation(summary = "마이페이지 특정 주소 조회", description = """
+    ## 특정 주소 조회를 수행합니다.
+    - 사용자가 등록한 주소 중, 특정 주소를 조회할 수 있습니다.
+    """)
+    @GetMapping("/me/addresses/{addressId}")
+    public ApiResponse<MemberAddressResponse> getMyAddresses(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @PathVariable Long addressId
+    ) {
+        return ApiResponse.success(memberFinder.findAddress(authDetails.getMemberId(), addressId));
+    }
+
     @Operation(summary = "주소 추가", description = """
     ## 주소 추가를 수행합니다.
     - 사용자가 주소를 추가할 수 있습니다.

--- a/src/main/java/hanieum/conik/application/member/MemberFinderService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberFinderService.java
@@ -54,4 +54,12 @@ public class MemberFinderService implements MemberFinder {
 
         return member.getCompanyId();
     }
+
+    @Override
+    public MemberAddressResponse findAddress(Long memberId, Long addressId) {
+        MemberAddress memberAddress = memberAddressRepository.findByIdAndMemberId(addressId, memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorType.ADDRESS_NOT_FOUND));
+
+        return MemberAddressResponse.from(memberAddress, memberAddress.getMember());
+    }
 }

--- a/src/main/java/hanieum/conik/application/member/MemberFinderService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberFinderService.java
@@ -36,11 +36,12 @@ public class MemberFinderService implements MemberFinder {
 
     @Override
     public Page<MemberAddressResponse> findAddresses(Long memberId, Pageable pageable) {
-       memberRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorType.MEMBER_NOT_FOUND));
+       Member member = memberRepository.findById(memberId)
+               .orElseThrow(() -> new MemberException(MemberErrorType.MEMBER_NOT_FOUND));
 
        Page<MemberAddress> memberAddresses = memberAddressRepository.findAllByMemberId(memberId, pageable);
 
-       return memberAddresses.map(MemberAddressResponse::from);
+       return memberAddresses.map(address -> MemberAddressResponse.from(address, member));
     }
 
     @Override

--- a/src/main/java/hanieum/conik/application/member/MemberModifyService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberModifyService.java
@@ -58,6 +58,13 @@ public class MemberModifyService implements MemberSaver {
     }
 
     @Override
+    public void updateAddress(Long memberId, Long addressId, AddressRegisterRequest request) {
+        Member member = memberFinder.findById(memberId);
+        MemberAddress address = MemberAddress.register(request);
+        member.updateAddress(addressId, address, request.isDefault());
+    }
+
+    @Override
     public void deleteAddress(Long memberId, Long addressId) {
         Member member = memberFinder.findById(memberId);
 

--- a/src/main/java/hanieum/conik/application/member/provided/MemberFinder.java
+++ b/src/main/java/hanieum/conik/application/member/provided/MemberFinder.java
@@ -14,4 +14,5 @@ public interface MemberFinder {
     Member findByEmail(Email email);
     Page<MemberAddressResponse> findAddresses(Long memberId, Pageable pageable);
     Long findCompanyIdByMemberId(Long memberId);
+    MemberAddressResponse findAddress(Long memberId, Long addressId);
 }

--- a/src/main/java/hanieum/conik/application/member/provided/MemberSaver.java
+++ b/src/main/java/hanieum/conik/application/member/provided/MemberSaver.java
@@ -26,6 +26,15 @@ public interface MemberSaver {
     void addAddress(Long memberId, AddressRegisterRequest addressRegister);
 
     /**
+     * 회원 주소를 수정합니다.
+     *
+     * @param memberId    수정할 멤버의 id
+     * @param addressId    수정할 주소의 id
+     * @param addressRegister   새로운 주소 정보를 담은 DTO
+     */
+    void updateAddress(Long memberId, Long addressId, AddressRegisterRequest addressRegister);
+
+    /**
      * 회원의 주소를 삭제합니다.
      *
      * @param memberId    수정할 멤버의 id

--- a/src/main/java/hanieum/conik/application/member/required/MemberAddressRepository.java
+++ b/src/main/java/hanieum/conik/application/member/required/MemberAddressRepository.java
@@ -6,7 +6,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberAddressRepository extends JpaRepository<MemberAddress, Long> {
     Page<MemberAddress> findAllByMemberId(Long memberId, Pageable pageable);
+    Optional<MemberAddress> findByIdAndMemberId(Long addressId, Long memberId);
 }

--- a/src/main/java/hanieum/conik/domain/common/address/AddressBase.java
+++ b/src/main/java/hanieum/conik/domain/common/address/AddressBase.java
@@ -42,4 +42,13 @@ public class AddressBase extends BaseEntity {
         this.recipient = recipient;
         this.phoneNumber = phoneNumber;
     }
+
+    protected void updateAddressBase(AddressBase addressBase) {
+        this.postalCode = addressBase.getPostalCode();
+        this.streetAddress = addressBase.getStreetAddress();
+        this.detailAddress = addressBase.getDetailAddress();
+        this.addressName = addressBase.getAddressName();
+        this.recipient = addressBase.getRecipient();
+        this.phoneNumber = addressBase.getPhoneNumber();
+    }
 }

--- a/src/main/java/hanieum/conik/domain/common/address/dto/AddressRegisterRequest.java
+++ b/src/main/java/hanieum/conik/domain/common/address/dto/AddressRegisterRequest.java
@@ -31,7 +31,7 @@ public record AddressRegisterRequest(
         String detailAddress,
 
         @Schema(description = "기본 배송지 여부", example = "false")
-        @JsonProperty("default")
+        @JsonProperty("default") // TODO: JSON 필드명 default로 고정한 이유가 궁금합니당
         @NotNull
         boolean isDefault
 ) {}

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -167,6 +167,27 @@ public class Member extends BaseEntity {
     }
 
     /**
+     * 회원 주소 수정
+     */
+    public void updateAddress(Long addressId, MemberAddress updatedAddress, boolean setAsDefault) {
+        MemberAddress target = addresses.stream()
+                .filter(a -> a.getId().equals(addressId))
+                .findFirst()
+                .orElseThrow(() -> new MemberException(MemberErrorType.ADDRESS_NOT_FOUND));
+
+        target.update(updatedAddress);
+
+        boolean wasDefault = (defaultAddress != null && defaultAddress.equals(target));
+        if (wasDefault && !setAsDefault) {
+            throw new MemberException(MemberErrorType.CANNOT_UNSET_DEFAULT_ADDRESS);
+        }
+
+        if (setAsDefault) {
+            setDefaultAddress(target);
+        }
+    }
+
+    /**
      * 회원 주소 삭제
      */
     public void deleteAddress(Long addressId) {

--- a/src/main/java/hanieum/conik/domain/member/MemberAddress.java
+++ b/src/main/java/hanieum/conik/domain/member/MemberAddress.java
@@ -61,4 +61,8 @@ public class MemberAddress extends AddressBase {
     void setMember(Member member) {
         this.member = member;
     }
+
+    public void update(MemberAddress address) {
+        updateAddressBase(address);
+    }
 }

--- a/src/main/java/hanieum/conik/domain/member/exception/MemberErrorType.java
+++ b/src/main/java/hanieum/conik/domain/member/exception/MemberErrorType.java
@@ -21,7 +21,8 @@ public enum MemberErrorType implements ErrorType {
     INVALID_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 이름입니다."),
     COMPANY_ID_MISSING(HttpStatus.UNPROCESSABLE_ENTITY, "기업 회원의 companyId가 누락되었습니다."),
     INVALID_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "유효하지 않은 이메일 인증 코드입니다."),
-    EXPIRED_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "이메일 인증 코드가 만료되었습니다.")
+    EXPIRED_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED,   "이메일 인증 코드가 만료되었습니다."),
+    CANNOT_UNSET_DEFAULT_ADDRESS(HttpStatus.BAD_REQUEST, "기본 배송지는 해제할 수 없습니다.")
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #95 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

소상공인 마이페이지 - 배송 정보 탭 필수 API를 구현한다.

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요

- 주소 정보 반환 시 기본 배송지 여부 추가
- 배송지 정보 수정 api 구현
- 로그인된 사옹자의 특정 배송지 정보 조회 api 구현

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

`// TODO` 로 질문과 논의 사항 좀 남겨뒀는데 확인부탁드려용
헥사고날 아키텍처 .. 에 맞는지도 봐주시면 감사하겠습니당

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 마이페이지에서 특정 배송지 단건 조회 가능
  - 배송지 수정 API 추가 (기본 배송지 설정 옵션 포함)
  - 배송지 응답에 기본 배송지 여부(isDefault) 표시
  - 기본 배송지를 해제하려는 경우 오류 메시지 제공

- Changes
  - 배송지 추가 API 메서드가 PATCH에서 POST로 변경
  - 단건 조회/수정 엔드포인트 추가: GET /v1/member/me/addresses/{addressId}, PUT /v1/member/addresses/{addressId}
<!-- end of auto-generated comment: release notes by coderabbit.ai -->