### PR TITLE
FIX: 내 정보 조회 시 주소 조회 방식을 변경한다

### DIFF
--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
@@ -15,8 +15,7 @@ public record MemberInfoResponse(
         boolean emailMarketingAgreed,
         boolean smsMarketingAgreed,
         MemberRole memberType,
-        List<MemberAddressResponse> addresses,
-        MemberAddressResponse defaultAddress
+        List<MemberAddressResponse> addresses
 ) {
     public static MemberInfoResponse from(Member member) {
         return new MemberInfoResponse(
@@ -29,9 +28,8 @@ public record MemberInfoResponse(
                 member.getSmsMarketingAgreed(),
                 member.getRole(),
                 member.getAddresses().stream()
-                        .map(MemberAddressResponse::from)
-                        .toList(),
-                MemberAddressResponse.from(member.getDefaultAddress())
+                        .map(address -> MemberAddressResponse.from(address, member))
+                        .toList()
         );
     }
 }

--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
@@ -27,7 +27,7 @@ public record MemberInfoResponse(
                 member.getEmailMarketingAgreed(),
                 member.getSmsMarketingAgreed(),
                 member.getRole(),
-                member.getAddresses().stream()
+                member.getSortedAddresses().stream()
                         .map(address -> MemberAddressResponse.from(address, member))
                         .toList()
         );

--- a/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
@@ -53,8 +53,7 @@ public class MemberController {
     public ApiResponse<MemberInfoResponse> getMemberInfo(
             @AuthenticationPrincipal AuthDetails authDetails
     ) {
-        Member member = memberFinder.findById(authDetails.getMemberId());
-        return ApiResponse.success(MemberInfoResponse.from(member));
+        return ApiResponse.success(memberFinder.getMemberInfo(authDetails.getMemberId()));
     }
 
     @Operation(summary = "회원 정보 - 이름 수정", description = """

--- a/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
+++ b/src/main/java/hanieum/conik/adapter/member/webapi/MemberController.java
@@ -48,6 +48,7 @@ public class MemberController {
     @Operation(summary = "내 정보 조회", description = """
     ## 내 정보를 조회합니다.
     - 사용자의 기본 정보를 조회할 수 있습니다.
+    - 주소 목록 중 기본 배송지는 먼저 조회됩니다.
     """)
     @GetMapping("/me")
     public ApiResponse<MemberInfoResponse> getMemberInfo(

--- a/src/main/java/hanieum/conik/application/member/MemberFinderService.java
+++ b/src/main/java/hanieum/conik/application/member/MemberFinderService.java
@@ -1,6 +1,7 @@
 package hanieum.conik.application.member;
 
 import hanieum.conik.adapter.member.dto.MemberAddressResponse;
+import hanieum.conik.adapter.member.dto.MemberInfoResponse;
 import hanieum.conik.application.member.provided.MemberFinder;
 import hanieum.conik.application.member.required.MemberAddressRepository;
 import hanieum.conik.application.member.required.MemberRepository;
@@ -52,5 +53,13 @@ public class MemberFinderService implements MemberFinder {
         }
 
         return member.getCompanyId();
+    }
+
+    @Override
+    public MemberInfoResponse getMemberInfo(Long memberId) {
+        Member member = memberRepository.findWithAddressesById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorType.MEMBER_NOT_FOUND));
+
+        return MemberInfoResponse.from(member);
     }
 }

--- a/src/main/java/hanieum/conik/application/member/provided/MemberFinder.java
+++ b/src/main/java/hanieum/conik/application/member/provided/MemberFinder.java
@@ -1,6 +1,7 @@
 package hanieum.conik.application.member.provided;
 
 import hanieum.conik.adapter.member.dto.MemberAddressResponse;
+import hanieum.conik.adapter.member.dto.MemberInfoResponse;
 import hanieum.conik.domain.member.Member;
 import hanieum.conik.domain.common.email.Email;
 import org.springframework.data.domain.Page;
@@ -14,4 +15,5 @@ public interface MemberFinder {
     Member findByEmail(Email email);
     Page<MemberAddressResponse> findAddresses(Long memberId, Pageable pageable);
     Long findCompanyIdByMemberId(Long memberId);
+    MemberInfoResponse getMemberInfo(Long memberId);
 }

--- a/src/main/java/hanieum/conik/application/member/required/MemberRepository.java
+++ b/src/main/java/hanieum/conik/application/member/required/MemberRepository.java
@@ -13,7 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         select distinct m
         from Member m
         left join fetch m.addresses
-        left join fetch m.defaultAddress d
         where m.id = :id
     """)
     Optional<Member> findWithAddressesById(@Param("id") Long id);

--- a/src/main/java/hanieum/conik/domain/member/Member.java
+++ b/src/main/java/hanieum/conik/domain/member/Member.java
@@ -166,6 +166,19 @@ public class Member extends BaseEntity {
     }
 
     /**
+     * 회원 주소 정렬 조회 (기본 배송지 먼저)
+     */
+    public List<MemberAddress> getSortedAddresses() {
+        return addresses.stream()
+                .sorted((a, b) -> {
+                    boolean aDefault = defaultAddress != null && defaultAddress.equals(a);
+                    boolean bDefault = defaultAddress != null && defaultAddress.equals(b);
+                    return Boolean.compare(bDefault, aDefault);
+                })
+                .toList();
+    }
+
+    /**
      * 회원 주소 추가
      */
     public void addAddress(MemberAddress address) {


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #101 


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

회원 주소 LazyInitializationException 문제를 해결합니다.


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요

[] 회원 주소 LazyInitializationException 문제 해결
[] 회원 주소 조회 시 기존 defaultAddress, Address 해서 기본 배송지 두 번 조회되던 문제 해결
[] 회원 주소 조회 시 기본 배송지 먼저 조회되도록 정렬


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 내 정보 조회 시 주소 목록이 기본 주소가 맨 앞에 오도록 정렬됩니다.
  - 별도의 기본 주소 항목 없이 하나의 주소 목록으로 제공되어 중복 없이 더 직관적으로 확인할 수 있습니다.
- Documentation
  - 내 정보 API 문서에 기본 주소가 주소 목록의 첫 번째로 반환됨을 명시했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->