### PR TITLE
FIX :  CompanyDetail 연관관계 및 생성 순서 수정으로 FK null 오류 해결

### DIFF
--- a/src/main/java/hanieum/conik/application/company/CompanyModifyService.java
+++ b/src/main/java/hanieum/conik/application/company/CompanyModifyService.java
@@ -14,7 +14,9 @@ import hanieum.conik.domain.company.entity.Equipment;
 import hanieum.conik.domain.company.entity.Portfolio;
 import hanieum.conik.domain.company.exception.CompanyErrorType;
 import hanieum.conik.domain.company.exception.CompanyException;
+import hanieum.conik.domain.member.Member;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,9 +44,8 @@ public class CompanyModifyService implements CompanySaver {
 
     @Override
     public Long registerCompanyDetail(Long memberId, CompanyDetailCreateRequest request) {
-        if (memberId == null || memberId <= 0) {
-            throw new CompanyException(CompanyErrorType.INVALID_INPUT);
-        }
+        Member member = memberFinder.findById(memberId); // 회원 존재 여부 확인
+        Company company = companyFinder.findCompany(member.getCompanyId());// 회원의 회사 존재 여부 확인
 
         if (request == null || request.detail() == null) {
             throw new CompanyException(CompanyErrorType.INVALID_INPUT);
@@ -55,29 +56,33 @@ public class CompanyModifyService implements CompanySaver {
             throw new CompanyException(CompanyErrorType.INVALID_INPUT);
         }
 
-        var member = memberFinder.findById(memberId);
-        Long companyId = member.getCompanyId();
-        if (companyId == null) throw new CompanyException(CompanyErrorType.COMPANY_NOT_FOUND);
-
-        Company company = companyRepository.findById(companyId)
-                .orElseThrow(() -> new CompanyException(CompanyErrorType.COMPANY_NOT_FOUND));
-
         if (company.getCompanyDetail() != null) {
             throw new CompanyException(CompanyErrorType.COMPANY_DETAIL_ALREADY_EXISTS);
         }
 
-        List<Equipment> equipments = Optional.ofNullable(request.equipments())
-                .orElseGet(List::of)
-                .stream().map(Equipment::create).toList();
-
-        List<Portfolio> portfolios = Optional.ofNullable(request.portfolios())
-                .orElseGet(List::of)
-                .stream().map(Portfolio::create).toList();
+        List<Equipment> equipments = registerEquipments(request);
+        List<Portfolio> portfolios = registerPortfolios(request);
 
         CompanyDetail companyDetail = CompanyDetail.create(company, request.detail(),equipments, portfolios);
         companyRepository.save(company);
 
         return companyDetail.getId();
+    }
+
+    @NotNull
+    private static List<Portfolio> registerPortfolios(CompanyDetailCreateRequest request) {
+        List<Portfolio> portfolios = Optional.ofNullable(request.portfolios())
+                .orElseGet(List::of)
+                .stream().map(Portfolio::create).toList();
+        return portfolios;
+    }
+
+    @NotNull
+    private static List<Equipment> registerEquipments(CompanyDetailCreateRequest request) {
+        List<Equipment> equipments = Optional.ofNullable(request.equipments())
+                .orElseGet(List::of)
+                .stream().map(Equipment::create).toList();
+        return equipments;
     }
 
     @Override

--- a/src/main/java/hanieum/conik/domain/company/dto/CompanyDetailCreateRequest.java
+++ b/src/main/java/hanieum/conik/domain/company/dto/CompanyDetailCreateRequest.java
@@ -14,8 +14,8 @@ public record CompanyDetailCreateRequest(
                 description = "보유 장비 목록(없으면 생략 또는 빈 배열)",
                 example = """
         [
-          {"name": "CNC 선반","description": "알루미늄 가공","quantity": 2,"imageUrl": ["https://cdn.example.com/equip/cnc-1.jpg", "https://cdn.example.com/equip/cnc-2.jpg"]},
-          {"name": "밀링 머신","description": "3축 밀링","quantity": 1, "imageUrl": ["https://cdn.example.com/equip/mill-1.jpg"]}
+          {"name": "CNC 선반","description": "알루미늄 가공","quantity": 2,"imageUrls": ["https://cdn.example.com/equip/cnc-1.jpg", "https://cdn.example.com/equip/cnc-2.jpg"]},
+          {"name": "밀링 머신","description": "3축 밀링","quantity": 1, "imageUrls": ["https://cdn.example.com/equip/mill-1.jpg"]}
         ]
         """
         )
@@ -28,8 +28,8 @@ public record CompanyDetailCreateRequest(
                 description = "포트폴리오 목록(없으면 생략 또는 빈 배열)",
                 example = """
             [
-              {"quantity": 100, "description": "브라켓 가공", "imageUrl": ["https://cdn.example.com/pf/bracket-1.jpg", "https://cdn.example.com/pf/bracket-2.jpg"], "category": "가공"},
-              {"quantity": 50,"description": "하우징 제작","imageUrl": ["https://cdn.example.com/pf/housing-1.jpg"], "category": "제작"}
+              {"quantity": 100, "description": "브라켓 가공", "imageUrls": ["https://cdn.example.com/pf/bracket-1.jpg", "https://cdn.example.com/pf/bracket-2.jpg"], "category": "가공"},
+              {"quantity": 50,"description": "하우징 제작","imageUrls": ["https://cdn.example.com/pf/housing-1.jpg"], "category": "제작"}
             ]
         """
         )

--- a/src/main/java/hanieum/conik/domain/company/entity/CompanyDetail.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/CompanyDetail.java
@@ -94,10 +94,10 @@ public class CompanyDetail extends BaseEntity {
 
         CompanyDetail detail = new CompanyDetail(company, request.establishedAt(), request.logoUrl(), request.employeeCount(), request.websiteUrl(), request.contactAvailableTime(), request.description());
 
+        company.attachDetail(detail);
+
         if (equipments != null) {equipments.forEach(detail::addEquipment);}
         if (portfolios != null) {portfolios.forEach(detail::addPortfolio);}
-
-        company.attachDetail(detail);
 
         return detail;
     }

--- a/src/main/java/hanieum/conik/domain/company/entity/Equipment.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/Equipment.java
@@ -14,11 +14,7 @@ import java.util.List;
 @Getter
 public class Equipment extends AbstractEntity {
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(
-            name = "company_id",
-            referencedColumnName = "company_id",
-            nullable = false
-    )
+    @JoinColumn(name = "company_id", nullable = false)
     private CompanyDetail companyDetail;
 
     @Column(nullable = false, length = 200)

--- a/src/main/java/hanieum/conik/domain/company/entity/Equipment.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/Equipment.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class Equipment extends AbstractEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id", nullable = false)
-    private CompanyDetail companyDetail;
+    private Company company;
 
     @Column(nullable = false, length = 200)
     private String name;
@@ -40,7 +40,7 @@ public class Equipment extends AbstractEntity {
         return new Equipment(request.name(), request.description(), request.quantity(), request.imageUrls());
     }
 
-    void setCompanyDetail(CompanyDetail detail) { this.companyDetail = detail; }
+    void setCompanyDetail(CompanyDetail detail) { this.company.attachDetail(detail);}
 
     public void update(EquipmentRequest request) {
         if (request.name() != null && !request.name().isBlank()) this.name = request.name().trim();
@@ -50,6 +50,6 @@ public class Equipment extends AbstractEntity {
     }
 
     public void remove() {
-        if (this.companyDetail != null) this.companyDetail.removeEquipment(this.getId());
+        if (this.company.getCompanyDetail() != null) this.company.getCompanyDetail().removeEquipment(this.getId());
     }
 }

--- a/src/main/java/hanieum/conik/domain/company/entity/Equipment.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/Equipment.java
@@ -14,8 +14,12 @@ import java.util.List;
 @Getter
 public class Equipment extends AbstractEntity {
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "company_id", nullable = false)
-    private Company company;
+    @JoinColumn(
+            name = "company_id",
+            referencedColumnName = "company_id",
+            nullable = false
+    )
+    private CompanyDetail companyDetail;
 
     @Column(nullable = false, length = 200)
     private String name;
@@ -40,7 +44,7 @@ public class Equipment extends AbstractEntity {
         return new Equipment(request.name(), request.description(), request.quantity(), request.imageUrls());
     }
 
-    void setCompanyDetail(CompanyDetail detail) { this.company.attachDetail(detail);}
+    void setCompanyDetail(CompanyDetail detail) { this.companyDetail = detail; }
 
     public void update(EquipmentRequest request) {
         if (request.name() != null && !request.name().isBlank()) this.name = request.name().trim();
@@ -50,6 +54,6 @@ public class Equipment extends AbstractEntity {
     }
 
     public void remove() {
-        if (this.company.getCompanyDetail() != null) this.company.getCompanyDetail().removeEquipment(this.getId());
+        if (this.companyDetail != null) this.companyDetail.removeEquipment(this.getId());
     }
 }

--- a/src/main/java/hanieum/conik/domain/company/entity/Portfolio.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/Portfolio.java
@@ -14,11 +14,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Portfolio extends AbstractEntity {
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(
-            name = "company_id",
-            referencedColumnName = "company_id",
-            nullable = false
-    )
+    @JoinColumn(name = "company_id", nullable = false)
     private CompanyDetail companyDetail;
 
     @Column(nullable = false)

--- a/src/main/java/hanieum/conik/domain/company/entity/Portfolio.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/Portfolio.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class Portfolio extends AbstractEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id", nullable = false)
-    private CompanyDetail companyDetail;
+    private Company company;
 
     @Column(nullable = false)
     private Integer quantity;
@@ -45,7 +45,7 @@ public class Portfolio extends AbstractEntity {
         );
     }
 
-    void setCompanyDetail(CompanyDetail detail) { this.companyDetail = detail; }
+    void setCompanyDetail(CompanyDetail detail) { this.company.attachDetail(detail);}
 
     public void update(PortfolioRequest request) {
         if (request.quantity() != null) this.quantity = Math.max(0, request.quantity());
@@ -55,6 +55,6 @@ public class Portfolio extends AbstractEntity {
     }
 
     public void remove() {
-        if (this.companyDetail != null) this.companyDetail.removePortfolio(this.getId());
+        if (this.company.getCompanyDetail() != null) this.company.getCompanyDetail().removePortfolio(this.getId());
     }
 }

--- a/src/main/java/hanieum/conik/domain/company/entity/Portfolio.java
+++ b/src/main/java/hanieum/conik/domain/company/entity/Portfolio.java
@@ -14,8 +14,12 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Portfolio extends AbstractEntity {
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "company_id", nullable = false)
-    private Company company;
+    @JoinColumn(
+            name = "company_id",
+            referencedColumnName = "company_id",
+            nullable = false
+    )
+    private CompanyDetail companyDetail;
 
     @Column(nullable = false)
     private Integer quantity;
@@ -45,7 +49,7 @@ public class Portfolio extends AbstractEntity {
         );
     }
 
-    void setCompanyDetail(CompanyDetail detail) { this.company.attachDetail(detail);}
+    void setCompanyDetail(CompanyDetail detail) { this.companyDetail = detail;}
 
     public void update(PortfolioRequest request) {
         if (request.quantity() != null) this.quantity = Math.max(0, request.quantity());
@@ -55,6 +59,6 @@ public class Portfolio extends AbstractEntity {
     }
 
     public void remove() {
-        if (this.company.getCompanyDetail() != null) this.company.getCompanyDetail().removePortfolio(this.getId());
+        if (this.companyDetail != null) this.companyDetail.removePortfolio(this.getId());
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #104 


## 📝 작업 내용
- CompanyDetail.create() 내부에서 company.attachDetail(detail) 호출 순서를 수정하여 @MapsId 관계에서 company_id가 null로 들어가는 문제 해결
- company.attachDetail(detail) 실행 후에 equipment / portfolio를 추가하도록 변경 → 자식 엔티티의 FK(company_detail_id)가 정상적으로 매핑되도록 보장
- 연관관계 매핑 구조를 정리 
> Equipment / Portfolio → CompanyDetail 단방향 @ManyToOne 유지
> CompanyDetail ↔ Company 간 @OneToOne @MapsId 구조 유지
- 불필요한 insert 순서 문제(ConstraintViolationException) 및 FK 제약 위반 에러 제거


## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 문서
  - API 예제에서 이미지 필드가 imageUrl에서 imageUrls로 변경되어 사용 방식이 명확해졌습니다.
- 리팩터링
  - 회원/회사 조회 흐름을 단일화하고 중복 로직을 제거했습니다.
  - 세부 정보 등록 시 참조 연결 시점을 정리했습니다.
  - 장비/포트폴리오 생성 절차를 헬퍼로 분리해 안정성과 가독성을 개선했습니다.
- 스타일
  - 사소한 코드 포맷이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->