### PR TITLE
FIX: 내 정보 조회 API null 가능한 필드 반환 형식을 수정한다

### DIFF
--- a/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
+++ b/src/main/java/hanieum/conik/adapter/member/dto/MemberInfoResponse.java
@@ -11,9 +11,9 @@ public record MemberInfoResponse(
         Email email,
         String name,
         String phoneNumber,
-        boolean termsOfServiceAgreed,
-        boolean emailMarketingAgreed,
-        boolean smsMarketingAgreed,
+        Boolean termsOfServiceAgreed,
+        Boolean emailMarketingAgreed,
+        Boolean smsMarketingAgreed,
         MemberRole memberType,
         List<MemberAddressResponse> addresses
 ) {


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #106 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- null 가능 필드 기본형 -> 객체 타입으로 변경

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 서비스 이용약관, 이메일·SMS 마케팅 동의 값이 제공되지 않을 때 자동으로 ‘미동의’로 처리되던 문제를 수정했습니다. 이제 동의 정보가 없는 경우 ‘알 수 없음’ 상태로 구분되어 프로필, 동의 설정 화면, 관련 알림 노출 및 필터링에 정확히 반영됩니다. 동의 현황 표시의 신뢰도가 향상되어 사용자가 실제 상태를 더 명확히 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->