### PR TITLE
FIX: 배포 중 빌드 시 베이스 이미지 deprecated 문제를 해결한다

### DIFF
--- a/deploy/Multistage.Dockerfile
+++ b/deploy/Multistage.Dockerfile
@@ -1,5 +1,5 @@
 # 빌드 단계
-FROM openjdk:21-jdk-slim AS builder
+FROM eclipse-temurin:21-jdk AS builder
 WORKDIR /app
 COPY gradlew build.gradle settings.gradle ./
 COPY gradle/ gradle/


### PR DESCRIPTION
## 💡 관련 이슈
> 관련된 이슈 번호를 적어주세요

- #116 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

openjdk 공식 이미지는 현재 사실상 deprecated 상태이며, 
특히 Java 21부터는 `openjdk:21-jdk-slim` 과 `openjdk:21-jdk` 은 존재하지 않으며
Java 21은 Eclipse Temurin 계열로 사실상 이전된 상태라고 합니다.

따라서 `openjdk:21-jdk-slim`로 설정되어있던 기존 베이스 이미지를 변경했습니다.

## 🧑‍💻 변경 사항
> 변경된 사항을 알려주세요

빌드 이미지 openjdk:21-jdk-slim -> eclipse-temurin:21-jdk로 변경했습니다.

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 빌드 인프라 기본 이미지를 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->